### PR TITLE
refactor(php): php ruleset and rector updates

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,30 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
-use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
 use Rector\CodeQuality\Rector\If_\SimplifyIfElseToTernaryRector;
-use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
-use Rector\Php80\Rector\Catch_\RemoveUnusedVariableInCatchRector;
-use Rector\Php80\Rector\ClassConstFetch\ClassOnThisVariableObjectRector;
-use Rector\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector;
-use Rector\Php80\Rector\ClassMethod\FinalPrivateToPrivateVisibilityRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Php80\Rector\Class_\StringableForToStringRector;
-use Rector\Php80\Rector\FuncCall\ClassOnObjectRector;
-use Rector\Php80\Rector\Identical\StrEndsWithRector;
-use Rector\Php80\Rector\Identical\StrStartsWithRector;
-use Rector\Php80\Rector\NotIdentical\StrContainsRector;
-use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
-use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
-use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
-use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
-use Rector\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector;
-use Rector\Php82\Rector\FuncCall\Utf8DecodeEncodeToMbConvertEncodingRector;
-use Rector\Php82\Rector\New_\FilesystemIteratorSkipDotsRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnNeverTypeRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -52,29 +31,9 @@ return RectorConfig::configure()
     )
     ->withPhpVersion(PhpVersion::PHP_82)
     ->withRules([
-        AddParamBasedOnParentClassMethodRector::class,
-        ChangeSwitchToMatchRector::class,
-        ClassOnObjectRector::class,
-        ClassOnThisVariableObjectRector::class,
-        ConsistentImplodeRector::class,
-        FilesystemIteratorSkipDotsRector::class,
-        FinalPrivateToPrivateVisibilityRector::class,
-        FirstClassCallableRector::class,
-        NullToStrictStringFuncCallArgRector::class,
-        OptionalParametersAfterRequiredRector::class,
-        ReadOnlyClassRector::class,
-        ReadOnlyPropertyRector::class,
-        RemoveParentCallWithoutParentRector::class,
-        RemoveUnusedVariableInCatchRector::class,
-        ReturnNeverTypeRector::class,
         SimplifyIfElseToTernaryRector::class,
-        StrContainsRector::class,
-        StrEndsWithRector::class,
-        StrStartsWithRector::class,
-        StringableForToStringRector::class,
-        Utf8DecodeEncodeToMbConvertEncodingRector::class,
-        VariableInStringInterpolationFixerRector::class,
     ])
+    ->withPhpSets()
     ->withSkip([
         __DIR__ . '/vendor',
     ])

--- a/src/Controller/WebhookController.php
+++ b/src/Controller/WebhookController.php
@@ -28,7 +28,7 @@ class WebhookController
 
     public function __construct(?GlobalsAccessor $globalsAccessor = null)
     {
-        $globalsAccessor = $globalsAccessor ?? new GlobalsAccessor();
+        $globalsAccessor ??= new GlobalsAccessor();
         $this->config = new GlobalConfig($globalsAccessor);
         $this->faxService = new FaxService($this->config);
         $this->logger = new SystemLogger();

--- a/src/Service/FaxService.php
+++ b/src/Service/FaxService.php
@@ -21,11 +21,9 @@ class FaxService
 {
     private readonly SinchFaxClient $client;
     private readonly SystemLogger $logger;
-    private readonly GlobalConfig $config;
 
-    public function __construct(?GlobalConfig $config = null)
+    public function __construct(private readonly GlobalConfig $config = new GlobalConfig())
     {
-        $this->config = $config ?? new GlobalConfig();
         $this->client = new SinchFaxClient($this->config);
         $this->logger = new SystemLogger();
     }


### PR DESCRIPTION
A recent version of rector deprecated a rule name. That caused an error.
Instead of fixing that explicitly, we switch to php rule sets.
