### PR TITLE
chore(docker): extend OpenEMR's docker-compose instead of standalone config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-yaml
+    args:
+    - --unsafe  # Allow custom tags like !override in compose.yml
   - id: check-added-large-files
   - id: check-merge-conflict
   - id: check-json
@@ -28,6 +30,7 @@ repos:
     args:
     - --autofix
     - --indent=2
+    exclude: ^compose\.yml$  # Uses Docker Compose !override tags
 
 - repo: local
   hooks:

--- a/compose.yml
+++ b/compose.yml
@@ -1,21 +1,86 @@
-services:
-  phpunit:
-    build:
-      context: .
-      dockerfile: Dockerfile.test
-    volumes:
-    - .:/app
-    - /app/vendor    # Use container's vendor for better performance
-    command: vendor/bin/phpunit --testdox
+# OpenEMR module development environment
+#
+# Extends OpenEMR's development-easy services with overrides:
+# - Random ports instead of fixed (8300, 9300, etc.)
+# - Module mounted into OpenEMR's custom_modules directory
+# - PHPUnit services available via profiles
 
-  phpunit-coverage:
+services:
+  openemr:
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: openemr
+    ports: !override
+    - "80"
+    - "443"
+    volumes:
+    - .:/var/www/localhost/htdocs/openemr/interface/modules/custom_modules/oce-module-sinch-fax:rw
+    healthcheck:
+      test: ["CMD", "curl", "-fsk", "https://localhost:443/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 3m
+
+  mysql:
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: mysql
+    ports: !override
+    - "3306"
+
+  phpmyadmin:
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: phpmyadmin
+    ports: !override
+    - "80"
+
+  couchdb:
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: couchdb
+    ports: !override
+    - "5984"
+    - "6984"
+
+  openldap:
+    extends:
+      file: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+      service: openldap
+
+  # PHPUnit test runner
+  phpunit:
+    profiles: [test]
     build:
       context: .
       dockerfile: Dockerfile.test
     volumes:
     - .:/app
     - /app/vendor
-    - ./htmlcov:/app/htmlcov    # Mount coverage directory to host
+    command: vendor/bin/phpunit --testdox
+
+  # PHPUnit with coverage
+  phpunit-coverage:
+    profiles: [test]
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    volumes:
+    - .:/app
+    - /app/vendor
+    - ./htmlcov:/app/htmlcov
     command: vendor/bin/phpunit --coverage-html htmlcov --coverage-text
     environment:
       XDEBUG_MODE: coverage
+
+volumes:
+  databasevolume: {}
+  assetvolume: {}
+  themevolume: {}
+  sitesvolume: {}
+  nodemodules: {}
+  vendordir: {}
+  ccdanodemodules: {}
+  logvolume: {}
+  couchdbvolume: {}

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,5 +1,30 @@
 # Docker Development Environment
 
+## Architecture
+
+The `compose.yml` in this repository extends OpenEMR's development-easy Docker setup:
+
+```
+compose.yml (this repo)
+    └── extends: vendor/openemr/openemr/docker/development-easy/docker-compose.yml
+```
+
+**What compose.yml does:**
+- Extends all services from OpenEMR's docker-compose.yml using `extends:`
+- Overrides ports with `!override` to use random ports (avoids conflicts)
+- Mounts this module into OpenEMR's custom_modules directory
+- Adds a healthcheck for the openemr service (waits for HTTP 200)
+- Includes PHPUnit services with `[test]` profile
+
+**Why this approach:**
+- OpenEMR is installed as a Composer dependency in `vendor/openemr/openemr/`
+- We reuse OpenEMR's official Docker setup without duplicating configuration
+- Changes to OpenEMR's Docker setup are automatically inherited
+- Project name is derived from directory (`oce-module-sinch-fax`)
+
+**First startup after purge:**
+The first `docker compose up -d --wait` after a fresh install takes 2-3 minutes while OpenEMR initializes. The healthcheck has a 3-minute start period to accommodate this.
+
 ## Quick Start Commands
 
 ```bash
@@ -169,11 +194,16 @@ docker compose exec -T mysql mariadb -uroot -proot openemr < module_backup.sql
 
 ## Environment Details
 
-**Services:**
+**Services (from OpenEMR's docker-compose):**
 - `openemr` - OpenEMR application server (Alpine Linux, PHP 8.2, Apache)
 - `mysql` - MariaDB 11.4 database
 - `phpmyadmin` - Web-based MySQL admin interface
-- `phpunit` / `phpunit-coverage` - Test runners
+- `couchdb` - CouchDB for document storage
+- `openldap` - LDAP server for authentication testing
+
+**Services (from this repo's compose.yml):**
+- `phpunit` - Test runner (profile: test)
+- `phpunit-coverage` - Test runner with coverage (profile: test)
 
 **Volumes:**
 - `databasevolume` - Persistent MySQL data


### PR DESCRIPTION
## Summary

- Refactors `compose.yml` to use `extends:` to inherit from OpenEMR's development-easy Docker setup
- Uses `!override` to replace fixed ports with random port assignment (avoids conflicts when running multiple modules)
- Mounts this module into OpenEMR's custom_modules directory automatically
- Adds healthcheck for openemr service with 3-minute start period for initial setup
- Updates pre-commit config to handle Docker Compose `!override` tags

## Why this approach

OpenEMR is installed as a Composer dependency in `vendor/openemr/openemr/`. By extending their official Docker configuration rather than duplicating it, we:

1. Inherit updates automatically when OpenEMR updates their Docker setup
2. Avoid maintaining duplicate service definitions
3. Keep our compose.yml focused on module-specific overrides

## Test plan

- [ ] Run `task dev:start` and verify containers start with random ports
- [ ] Run `task dev:browse` and verify OpenEMR loads
- [ ] Verify module is mounted: `docker compose exec openemr ls /var/www/localhost/htdocs/openemr/interface/modules/custom_modules/oce-module-sinch-fax/`
- [ ] Run `docker compose ps` and verify healthcheck shows "(healthy)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)