### PR TITLE
feat: add environment-based configuration mode

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,0 +1,38 @@
+# Environment configuration for testing env-based config mode
+# Copy to .env.testing and fill in real values
+#
+# Usage:
+#   cp .env.testing.example .env.testing
+#   # Edit .env.testing with your values
+#   docker compose up -d --wait
+
+# Enable environment-based configuration (disables UI config)
+OCE_SINCH_FAX_ENV_CONFIG=1
+
+# Module enabled
+OCE_SINCH_FAX_ENABLED=1
+
+# Sinch API credentials (get from Sinch dashboard)
+OCE_SINCH_FAX_PROJECT_ID=
+OCE_SINCH_FAX_SERVICE_ID=
+OCE_SINCH_FAX_AUTH_METHOD=basic
+OCE_SINCH_FAX_API_KEY=
+OCE_SINCH_FAX_API_SECRET=
+OCE_SINCH_FAX_OAUTH_TOKEN=
+
+# API region (global, use1, eu1, sae1, apse1, apse2)
+OCE_SINCH_FAX_REGION=global
+
+# File storage (leave empty for default)
+OCE_SINCH_FAX_FILE_STORAGE_PATH=
+
+# Retry count for failed sends
+OCE_SINCH_FAX_DEFAULT_RETRY_COUNT=3
+
+# Webhook authentication (for receiving Sinch callbacks)
+OCE_SINCH_FAX_WEBHOOK_USERNAME=
+OCE_SINCH_FAX_WEBHOOK_PASSWORD=
+
+# Webhook IP whitelist (comma-separated, supports CIDR notation)
+# Leave empty to allow all IPs
+OCE_SINCH_FAX_WEBHOOK_IP_WHITELIST=

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Thumbs.db
 
 # Docker
 .docker/
+compose.override.yml
+
+# Environment files with secrets
+.env.testing

--- a/compose.override.yml.example
+++ b/compose.override.yml.example
@@ -1,0 +1,13 @@
+# Docker Compose override for local testing
+# Copy to compose.override.yml (which is gitignored and auto-loaded by docker compose)
+#
+# Usage:
+#   cp compose.override.yml.example compose.override.yml
+#   cp .env.testing.example .env.testing
+#   # Edit .env.testing with your values
+#   docker compose up -d --wait
+
+services:
+  openemr:
+    env_file:
+      - .env.testing

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -220,6 +220,46 @@ docker compose exec -T mysql mariadb -uroot -proot openemr < module_backup.sql
 - MySQL: Random port (use `docker compose port mysql 3306`)
 - phpMyAdmin: Random port (use `docker compose port phpmyadmin 80`)
 
+## Local Configuration Overrides
+
+For local testing with custom configuration (e.g., testing environment-based config mode), use these gitignored files:
+
+**`.env.testing`** - Environment variables loaded into the OpenEMR container:
+```bash
+# Enable environment-based configuration
+OCE_SINCH_FAX_ENV_CONFIG=1
+OCE_SINCH_FAX_ENABLED=1
+OCE_SINCH_FAX_PROJECT_ID=your-project-id
+OCE_SINCH_FAX_API_KEY=your-api-key
+OCE_SINCH_FAX_API_SECRET=your-secret
+# ... other OCE_SINCH_FAX_* variables
+```
+
+**`compose.override.yml`** - Docker Compose overrides (automatically loaded):
+```yaml
+services:
+  openemr:
+    env_file:
+      - .env.testing
+```
+
+**Usage:**
+```bash
+# Create your local config files (gitignored)
+cp .env.testing.example .env.testing  # if example exists, or create from scratch
+# Edit .env.testing with your values
+
+# Start containers - compose.override.yml is auto-loaded
+docker compose up -d --wait
+
+# The module now uses environment variables instead of database config
+```
+
+This pattern is useful for:
+- Testing environment-based configuration mode (`OCE_SINCH_FAX_ENV_CONFIG=1`)
+- Using real Sinch API credentials without committing them
+- Simulating production deployment configurations locally
+
 ## Best Practices
 
 1. Use `docker compose` (not `docker-compose`) - newer syntax
@@ -231,3 +271,4 @@ docker compose exec -T mysql mariadb -uroot -proot openemr < module_backup.sql
 7. Check logs first when debugging issues
 8. Verify container health with `docker compose ps`
 9. Remember that local file changes are instant
+10. Use `.env.testing` and `compose.override.yml` for local config overrides (both gitignored)

--- a/public/contact.php
+++ b/public/contact.php
@@ -15,6 +15,7 @@ require_once(__DIR__ . "/../../../../globals.php");
 require_once(__DIR__ . "/../../../../../library/classes/Document.class.php");
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
+use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
 
 // Get kernel and bootstrap module
@@ -23,7 +24,8 @@ $kernel = $globalsAccessor->get('kernel');
 if (!$kernel instanceof \OpenEMR\Core\Kernel) {
     throw new \RuntimeException('OpenEMR Kernel not available');
 }
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+$configAccessor = ConfigFactory::createConfigAccessor();
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $configAccessor);
 
 // Get controller
 $controller = $bootstrap->getDocumentFaxController();

--- a/public/download.php
+++ b/public/download.php
@@ -13,6 +13,7 @@
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
+use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxExceptionInterface;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxValidationException;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
@@ -24,7 +25,8 @@ $kernel = $globalsAccessor->get('kernel');
 if (!$kernel instanceof \OpenEMR\Core\Kernel) {
     throw new \RuntimeException('OpenEMR Kernel not available');
 }
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+$configAccessor = ConfigFactory::createConfigAccessor();
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $configAccessor);
 
 // Get controller
 $controller = $bootstrap->getFaxDownloadController();

--- a/public/index.php
+++ b/public/index.php
@@ -14,6 +14,7 @@ $sessionAllowWrite = true;
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
+use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
 
 // Get kernel and bootstrap module
@@ -22,7 +23,8 @@ $kernel = $globalsAccessor->get('kernel');
 if (!$kernel instanceof \OpenEMR\Core\Kernel) {
     throw new \RuntimeException('OpenEMR Kernel not available');
 }
-$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+$configAccessor = ConfigFactory::createConfigAccessor();
+$bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $configAccessor);
 
 // Get controller
 $controller = $bootstrap->getFaxListController();

--- a/public/webhook.php
+++ b/public/webhook.php
@@ -18,6 +18,7 @@ $ignoreAuth = true;
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
+use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxExceptionInterface;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -32,7 +33,8 @@ try {
     if (!$kernel instanceof \OpenEMR\Core\Kernel) {
         throw new \RuntimeException('OpenEMR Kernel not available');
     }
-    $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $globalsAccessor);
+    $configAccessor = ConfigFactory::createConfigAccessor();
+    $bootstrap = new Bootstrap($kernel->getEventDispatcher(), $kernel, $configAccessor);
 
     // Get webhook controller and dispatch
     $controller = $bootstrap->getWebhookController();

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -37,9 +37,10 @@ class Bootstrap
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly Kernel $kernel = new Kernel(),
-        private readonly GlobalsAccessor $globals = new GlobalsAccessor()
+        ?ConfigAccessorInterface $configAccessor = null
     ) {
-        $this->globalsConfig = new GlobalConfig($this->globals);
+        $configAccessor ??= ConfigFactory::createConfigAccessor();
+        $this->globalsConfig = new GlobalConfig($configAccessor);
 
         $templatePath = \dirname(__DIR__) . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR;
         $twig = new TwigContainer($templatePath, $this->kernel);
@@ -95,17 +96,35 @@ class Bootstrap
         $section = xlt("OpenCoreEMR Sinch Fax Module");
         $service->createSection($section, 'Fax');
 
+        // In env config mode, show informational message instead of editable fields
+        if ($this->globalsConfig->isEnvConfigMode()) {
+            $setting = new GlobalSetting(
+                xlt('Configuration Managed Externally'),
+                GlobalSetting::DATA_TYPE_HTML_DISPLAY_SECTION,
+                '',
+                '',
+                false
+            );
+            $setting->addFieldOption(
+                GlobalSetting::DATA_TYPE_OPTION_RENDER_CALLBACK,
+                static fn() => xlt(
+                    'This module is managed by deployment administrators.'
+                )
+            );
+            $service->appendToSection($section, 'oce_sinch_fax_env_config_notice', $setting);
+            return;
+        }
+
         $settings = $this->globalsConfig->getGlobalSettingSectionConfiguration();
 
         foreach ($settings as $key => $config) {
-            $value = $this->globals->get($key, $config['default']);
             $service->appendToSection(
                 $section,
                 $key,
                 new GlobalSetting(
                     xlt($config['title']),
                     $config['type'],
-                    $value,
+                    $config['default'],
                     xlt($config['description']),
                     true
                 )
@@ -134,7 +153,11 @@ class Bootstrap
         $menuItem->icon = 'fa-fax';
         $menuItem->children = [];
         $menuItem->acl_req = ["patients", "demo"];
-        $menuItem->global_req = ["oce_sinch_fax_enabled"];
+
+        // In env config mode, skip global_req check (menu always visible when module is enabled)
+        if (!$this->globalsConfig->isEnvConfigMode()) {
+            $menuItem->global_req = ["oce_sinch_fax_enabled"];
+        }
 
         foreach ($menu as $item) {
             if ($item->menu_id == 'modimg') {

--- a/src/ConfigAccessorInterface.php
+++ b/src/ConfigAccessorInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Interface for typed configuration access
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax;
+
+/**
+ * Abstraction for configuration access, matching Symfony ParameterBag's typed accessor methods.
+ * Allows configuration to be read from either OpenEMR globals (database) or environment variables.
+ */
+interface ConfigAccessorInterface
+{
+    /**
+     * Get a configuration value
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * Get a string configuration value
+     */
+    public function getString(string $key, string $default = ''): string;
+
+    /**
+     * Get a boolean configuration value
+     */
+    public function getBoolean(string $key, bool $default = false): bool;
+
+    /**
+     * Get an integer configuration value
+     */
+    public function getInt(string $key, int $default = 0): int;
+
+    /**
+     * Check if a configuration key exists
+     */
+    public function has(string $key): bool;
+}

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Factory for creating configuration accessors
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax;
+
+/**
+ * Factory for creating the appropriate configuration accessor.
+ *
+ * When OCE_SINCH_FAX_ENV_CONFIG=1 is set, configuration is read from
+ * environment variables instead of the database-backed OpenEMR globals.
+ */
+class ConfigFactory
+{
+    public const ENV_CONFIG_VAR = 'OCE_SINCH_FAX_ENV_CONFIG';
+
+    /**
+     * Check if environment-only config mode is enabled
+     */
+    public static function isEnvConfigMode(): bool
+    {
+        $value = getenv(self::ENV_CONFIG_VAR);
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Create the appropriate config accessor based on environment
+     */
+    public static function createConfigAccessor(): ConfigAccessorInterface
+    {
+        if (self::isEnvConfigMode()) {
+            return new EnvironmentConfigAccessor();
+        }
+        return new GlobalsAccessor();
+    }
+}

--- a/src/EnvironmentConfigAccessor.php
+++ b/src/EnvironmentConfigAccessor.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Environment-based configuration accessor
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * Reads module configuration from environment variables.
+ *
+ * This accessor is used when OCE_SINCH_FAX_ENV_CONFIG=1 is set,
+ * bypassing the database-backed globals system entirely for module config.
+ * OpenEMR system values (OE_SITE_DIR, webroot, etc.) are still delegated
+ * to GlobalsAccessor since they are not module configuration.
+ */
+class EnvironmentConfigAccessor implements ConfigAccessorInterface
+{
+    /**
+     * Maps internal config keys (oce_sinch_fax_*) to env var names (OCE_SINCH_FAX_*)
+     */
+    private const KEY_MAP = [
+        GlobalConfig::CONFIG_OPTION_ENABLED => 'OCE_SINCH_FAX_ENABLED',
+        GlobalConfig::CONFIG_OPTION_PROJECT_ID => 'OCE_SINCH_FAX_PROJECT_ID',
+        GlobalConfig::CONFIG_OPTION_SERVICE_ID => 'OCE_SINCH_FAX_SERVICE_ID',
+        GlobalConfig::CONFIG_OPTION_AUTH_METHOD => 'OCE_SINCH_FAX_AUTH_METHOD',
+        GlobalConfig::CONFIG_OPTION_API_KEY => 'OCE_SINCH_FAX_API_KEY',
+        GlobalConfig::CONFIG_OPTION_API_SECRET => 'OCE_SINCH_FAX_API_SECRET',
+        GlobalConfig::CONFIG_OPTION_OAUTH_TOKEN => 'OCE_SINCH_FAX_OAUTH_TOKEN',
+        GlobalConfig::CONFIG_OPTION_REGION => 'OCE_SINCH_FAX_REGION',
+        GlobalConfig::CONFIG_OPTION_FILE_STORAGE_PATH => 'OCE_SINCH_FAX_FILE_STORAGE_PATH',
+        GlobalConfig::CONFIG_OPTION_DEFAULT_RETRY_COUNT => 'OCE_SINCH_FAX_DEFAULT_RETRY_COUNT',
+        GlobalConfig::CONFIG_OPTION_WEBHOOK_USERNAME => 'OCE_SINCH_FAX_WEBHOOK_USERNAME',
+        GlobalConfig::CONFIG_OPTION_WEBHOOK_PASSWORD => 'OCE_SINCH_FAX_WEBHOOK_PASSWORD',
+        GlobalConfig::CONFIG_OPTION_WEBHOOK_IP_WHITELIST => 'OCE_SINCH_FAX_WEBHOOK_IP_WHITELIST',
+    ];
+
+    private readonly ParameterBag $envBag;
+    private readonly GlobalsAccessor $globalsAccessor;
+
+    public function __construct()
+    {
+        $this->globalsAccessor = new GlobalsAccessor();
+        $this->envBag = $this->buildEnvBag();
+    }
+
+    /**
+     * Build a ParameterBag from environment variables
+     *
+     * @return ParameterBag<string, mixed>
+     */
+    private function buildEnvBag(): ParameterBag
+    {
+        $params = [];
+        foreach (self::KEY_MAP as $configKey => $envVar) {
+            $value = getenv($envVar);
+            if ($value !== false) {
+                $params[$configKey] = $value;
+            }
+        }
+        return new ParameterBag($params);
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        // Check if this is a module config key
+        if (isset(self::KEY_MAP[$key])) {
+            return $this->envBag->get($key, $default);
+        }
+
+        // For OpenEMR system values, delegate to GlobalsAccessor
+        return $this->globalsAccessor->get($key, $default);
+    }
+
+    public function getString(string $key, string $default = ''): string
+    {
+        if (isset(self::KEY_MAP[$key])) {
+            return $this->envBag->getString($key, $default);
+        }
+
+        return $this->globalsAccessor->getString($key, $default);
+    }
+
+    public function getBoolean(string $key, bool $default = false): bool
+    {
+        if (isset(self::KEY_MAP[$key])) {
+            return $this->envBag->getBoolean($key, $default);
+        }
+
+        return $this->globalsAccessor->getBoolean($key, $default);
+    }
+
+    public function getInt(string $key, int $default = 0): int
+    {
+        if (isset(self::KEY_MAP[$key])) {
+            return $this->envBag->getInt($key, $default);
+        }
+
+        return $this->globalsAccessor->getInt($key, $default);
+    }
+
+    public function has(string $key): bool
+    {
+        if (isset(self::KEY_MAP[$key])) {
+            return $this->envBag->has($key);
+        }
+
+        return $this->globalsAccessor->has($key);
+    }
+}

--- a/src/GlobalConfig.php
+++ b/src/GlobalConfig.php
@@ -18,12 +18,23 @@ use Symfony\Component\HttpFoundation\IpUtils;
 
 class GlobalConfig
 {
+    private readonly bool $isEnvConfigMode;
+
     public function __construct(
-        private readonly GlobalsAccessor $globals = new GlobalsAccessor()
+        private readonly ConfigAccessorInterface $configAccessor = new GlobalsAccessor()
     ) {
+        $this->isEnvConfigMode = ConfigFactory::isEnvConfigMode();
     }
 
     public const CONFIG_OPTION_ENABLED = 'oce_sinch_fax_enabled';
+
+    /**
+     * Check if configuration is managed via environment variables
+     */
+    public function isEnvConfigMode(): bool
+    {
+        return $this->isEnvConfigMode;
+    }
     public const CONFIG_OPTION_PROJECT_ID = 'oce_sinch_fax_project_id';
     public const CONFIG_OPTION_SERVICE_ID = 'oce_sinch_fax_service_id';
     public const CONFIG_OPTION_AUTH_METHOD = 'oce_sinch_fax_auth_method';
@@ -39,33 +50,37 @@ class GlobalConfig
 
     public function isEnabled(): bool
     {
-        return $this->globals->getBoolean(self::CONFIG_OPTION_ENABLED, false);
+        return $this->configAccessor->getBoolean(self::CONFIG_OPTION_ENABLED, false);
     }
 
     public function getProjectId(): string
     {
-        return $this->globals->getString(self::CONFIG_OPTION_PROJECT_ID, '');
+        return $this->configAccessor->getString(self::CONFIG_OPTION_PROJECT_ID, '');
     }
 
     public function getServiceId(): string
     {
-        return $this->globals->getString(self::CONFIG_OPTION_SERVICE_ID, '');
+        return $this->configAccessor->getString(self::CONFIG_OPTION_SERVICE_ID, '');
     }
 
     public function getAuthMethod(): string
     {
-        return $this->globals->getString(self::CONFIG_OPTION_AUTH_METHOD, 'basic');
+        return $this->configAccessor->getString(self::CONFIG_OPTION_AUTH_METHOD, 'basic');
     }
 
     public function getApiKey(): string
     {
-        return $this->globals->getString(self::CONFIG_OPTION_API_KEY, '');
+        return $this->configAccessor->getString(self::CONFIG_OPTION_API_KEY, '');
     }
 
     public function getApiSecret(): string
     {
-        $value = $this->globals->getString(self::CONFIG_OPTION_API_SECRET, '');
+        $value = $this->configAccessor->getString(self::CONFIG_OPTION_API_SECRET, '');
         if (!empty($value)) {
+            // In env config mode, secrets are stored as plaintext (no encryption)
+            if ($this->isEnvConfigMode) {
+                return $value;
+            }
             $cryptoGen = new CryptoGen();
             $decrypted = $cryptoGen->decryptStandard($value);
             return $decrypted !== false ? $decrypted : '';
@@ -75,8 +90,12 @@ class GlobalConfig
 
     public function getOAuthToken(): string
     {
-        $value = $this->globals->getString(self::CONFIG_OPTION_OAUTH_TOKEN, '');
+        $value = $this->configAccessor->getString(self::CONFIG_OPTION_OAUTH_TOKEN, '');
         if (!empty($value)) {
+            // In env config mode, secrets are stored as plaintext (no encryption)
+            if ($this->isEnvConfigMode) {
+                return $value;
+            }
             $cryptoGen = new CryptoGen();
             $decrypted = $cryptoGen->decryptStandard($value);
             return $decrypted !== false ? $decrypted : '';
@@ -86,32 +105,36 @@ class GlobalConfig
 
     public function getRegion(): string
     {
-        return $this->globals->getString(self::CONFIG_OPTION_REGION, 'global');
+        return $this->configAccessor->getString(self::CONFIG_OPTION_REGION, 'global');
     }
 
     public function getFileStoragePath(): string
     {
-        $path = $this->globals->getString(self::CONFIG_OPTION_FILE_STORAGE_PATH, '');
+        $path = $this->configAccessor->getString(self::CONFIG_OPTION_FILE_STORAGE_PATH, '');
         if (empty($path)) {
-            $path = $this->globals->getString('OE_SITE_DIR', '') . '/documents/sinch_faxes';
+            $path = $this->configAccessor->getString('OE_SITE_DIR', '') . '/documents/sinch_faxes';
         }
         return $path;
     }
 
     public function getDefaultRetryCount(): int
     {
-        return $this->globals->getInt(self::CONFIG_OPTION_DEFAULT_RETRY_COUNT, 3);
+        return $this->configAccessor->getInt(self::CONFIG_OPTION_DEFAULT_RETRY_COUNT, 3);
     }
 
     public function getWebhookUsername(): string
     {
-        return $this->globals->getString(self::CONFIG_OPTION_WEBHOOK_USERNAME, '');
+        return $this->configAccessor->getString(self::CONFIG_OPTION_WEBHOOK_USERNAME, '');
     }
 
     public function getWebhookPassword(): string
     {
-        $value = $this->globals->getString(self::CONFIG_OPTION_WEBHOOK_PASSWORD, '');
+        $value = $this->configAccessor->getString(self::CONFIG_OPTION_WEBHOOK_PASSWORD, '');
         if (!empty($value)) {
+            // In env config mode, secrets are stored as plaintext (no encryption)
+            if ($this->isEnvConfigMode) {
+                return $value;
+            }
             $cryptoGen = new CryptoGen();
             $decrypted = $cryptoGen->decryptStandard($value);
             return $decrypted !== false ? $decrypted : '';
@@ -121,20 +144,24 @@ class GlobalConfig
 
     /**
      * Get the webhook IP whitelist as an array of IP addresses or CIDR ranges
+     * Supports both newline-delimited (from UI textarea) and comma-delimited (from env vars)
      *
      * @return array<int, string>
      */
     public function getWebhookIpWhitelist(): array
     {
-        $value = $this->globals->getString(self::CONFIG_OPTION_WEBHOOK_IP_WHITELIST, '');
+        $value = $this->configAccessor->getString(self::CONFIG_OPTION_WEBHOOK_IP_WHITELIST, '');
         if (empty($value)) {
             return [];
         }
-        // Split by newlines and filter empty values
-        $lines = explode("\n", $value);
+        // Split by newlines or commas and filter empty values
+        $parts = preg_split('/[\n,]+/', $value);
+        if ($parts === false) {
+            return [];
+        }
         $entries = [];
-        foreach ($lines as $line) {
-            $trimmed = trim($line);
+        foreach ($parts as $part) {
+            $trimmed = trim($part);
             if ($trimmed !== '') {
                 $entries[] = $trimmed;
             }
@@ -179,17 +206,17 @@ class GlobalConfig
 
     public function getSiteAddrOath(): string
     {
-        return $this->globals->getString('site_addr_oath', '');
+        return $this->configAccessor->getString('site_addr_oath', '');
     }
 
     public function getWebroot(): string
     {
-        return $this->globals->getString('webroot', '');
+        return $this->configAccessor->getString('webroot', '');
     }
 
     public function getAssetsStaticRelative(): string
     {
-        return $this->globals->getString('assets_static_relative', '');
+        return $this->configAccessor->getString('assets_static_relative', '');
     }
 
     public function isConfigured(): bool

--- a/src/GlobalsAccessor.php
+++ b/src/GlobalsAccessor.php
@@ -17,7 +17,7 @@ namespace OpenCoreEMR\Modules\SinchFax;
  * This class serves as a single point of abstraction for globals access,
  * making it easier to update or refactor in the future.
  */
-class GlobalsAccessor
+class GlobalsAccessor implements ConfigAccessorInterface
 {
     /**
      * Get a value from globals

--- a/tests/Mocks/MockEnvironmentConfigAccessor.php
+++ b/tests/Mocks/MockEnvironmentConfigAccessor.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Mock EnvironmentConfigAccessor for testing
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax\Tests\Mocks;
+
+use OpenCoreEMR\Modules\SinchFax\ConfigAccessorInterface;
+
+/**
+ * Mock implementation of ConfigAccessorInterface for testing environment config mode
+ */
+class MockEnvironmentConfigAccessor implements ConfigAccessorInterface
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $data = [];
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data = [])
+    {
+        $this->data = $data;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->data[$key] ?? $default;
+    }
+
+    public function getString(string $key, string $default = ''): string
+    {
+        $value = $this->data[$key] ?? $default;
+        return is_string($value) ? $value : (is_scalar($value) ? (string)$value : $default);
+    }
+
+    public function getBoolean(string $key, bool $default = false): bool
+    {
+        $value = $this->data[$key] ?? $default;
+        if (is_bool($value)) {
+            return $value;
+        }
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    public function getInt(string $key, int $default = 0): int
+    {
+        $value = $this->data[$key] ?? $default;
+        return is_numeric($value) ? (int)$value : $default;
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->data[$key]);
+    }
+
+    /**
+     * Set a value for testing
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $this->data[$key] = $value;
+    }
+}

--- a/tests/Mocks/MockGlobalsAccessor.php
+++ b/tests/Mocks/MockGlobalsAccessor.php
@@ -12,9 +12,10 @@
 
 namespace OpenCoreEMR\Modules\SinchFax\Tests\Mocks;
 
+use OpenCoreEMR\Modules\SinchFax\ConfigAccessorInterface;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
 
-class MockGlobalsAccessor extends GlobalsAccessor
+class MockGlobalsAccessor extends GlobalsAccessor implements ConfigAccessorInterface
 {
     /**
      * @var array<string, mixed>
@@ -73,5 +74,10 @@ class MockGlobalsAccessor extends GlobalsAccessor
     public function set(string $key, mixed $value): void
     {
         $this->mockData[$key] = $value;
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->mockData[$key]);
     }
 }

--- a/tests/Unit/BootstrapTest.php
+++ b/tests/Unit/BootstrapTest.php
@@ -43,7 +43,7 @@ class BootstrapTest extends TestCase
             GlobalConfig::CONFIG_OPTION_REGION => 'use1',
         ]);
 
-        $this->bootstrap = new Bootstrap($this->eventDispatcher, globals: $mockGlobals);
+        $this->bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $mockGlobals);
     }
 
     protected function tearDown(): void
@@ -105,7 +105,7 @@ class BootstrapTest extends TestCase
             // Missing required config
         ]);
 
-        $bootstrap = new Bootstrap($this->eventDispatcher, globals: $mockGlobals);
+        $bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $mockGlobals);
 
         SystemLogger::clearLogs();
         $bootstrap->subscribeToEvents();
@@ -129,7 +129,7 @@ class BootstrapTest extends TestCase
             GlobalConfig::CONFIG_OPTION_REGION => 'use1',
         ]);
 
-        $bootstrap = new Bootstrap($this->eventDispatcher, globals: $mockGlobals);
+        $bootstrap = new Bootstrap($this->eventDispatcher, configAccessor: $mockGlobals);
 
         SystemLogger::clearLogs();
         $bootstrap->subscribeToEvents();

--- a/tests/Unit/ConfigFactoryTest.php
+++ b/tests/Unit/ConfigFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Unit tests for ConfigFactory
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
+use OpenCoreEMR\Modules\SinchFax\EnvironmentConfigAccessor;
+use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
+use PHPUnit\Framework\TestCase;
+
+class ConfigFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR);
+    }
+
+    public function testIsEnvConfigModeReturnsFalseByDefault(): void
+    {
+        $this->assertFalse(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsTrueWhenSetTo1(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=1');
+
+        $this->assertTrue(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsTrueWhenSetToTrue(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=true');
+
+        $this->assertTrue(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsFalseWhenSetTo0(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=0');
+
+        $this->assertFalse(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testIsEnvConfigModeReturnsFalseWhenSetToFalse(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=false');
+
+        $this->assertFalse(ConfigFactory::isEnvConfigMode());
+    }
+
+    public function testCreateConfigAccessorReturnsGlobalsAccessorByDefault(): void
+    {
+        $accessor = ConfigFactory::createConfigAccessor();
+
+        $this->assertInstanceOf(GlobalsAccessor::class, $accessor);
+    }
+
+    public function testCreateConfigAccessorReturnsEnvironmentAccessorWhenEnvSet(): void
+    {
+        putenv(ConfigFactory::ENV_CONFIG_VAR . '=1');
+
+        $accessor = ConfigFactory::createConfigAccessor();
+
+        $this->assertInstanceOf(EnvironmentConfigAccessor::class, $accessor);
+    }
+
+    public function testEnvConfigVarConstant(): void
+    {
+        $this->assertEquals('OCE_SINCH_FAX_ENV_CONFIG', ConfigFactory::ENV_CONFIG_VAR);
+    }
+}

--- a/tests/Unit/EnvironmentConfigAccessorTest.php
+++ b/tests/Unit/EnvironmentConfigAccessorTest.php
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * Unit tests for EnvironmentConfigAccessor
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchFax\EnvironmentConfigAccessor;
+use OpenCoreEMR\Modules\SinchFax\GlobalConfig;
+use PHPUnit\Framework\TestCase;
+
+class EnvironmentConfigAccessorTest extends TestCase
+{
+    /**
+     * @var array<string, string> Environment variables to clean up
+     */
+    private array $envVarsToClean = [
+        'OCE_SINCH_FAX_ENABLED',
+        'OCE_SINCH_FAX_PROJECT_ID',
+        'OCE_SINCH_FAX_SERVICE_ID',
+        'OCE_SINCH_FAX_AUTH_METHOD',
+        'OCE_SINCH_FAX_API_KEY',
+        'OCE_SINCH_FAX_API_SECRET',
+        'OCE_SINCH_FAX_OAUTH_TOKEN',
+        'OCE_SINCH_FAX_REGION',
+        'OCE_SINCH_FAX_FILE_STORAGE_PATH',
+        'OCE_SINCH_FAX_DEFAULT_RETRY_COUNT',
+        'OCE_SINCH_FAX_WEBHOOK_USERNAME',
+        'OCE_SINCH_FAX_WEBHOOK_PASSWORD',
+        'OCE_SINCH_FAX_WEBHOOK_IP_WHITELIST',
+    ];
+
+    protected function setUp(): void
+    {
+        $this->clearEnvVars();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearEnvVars();
+    }
+
+    private function clearEnvVars(): void
+    {
+        foreach ($this->envVarsToClean as $var) {
+            putenv($var);
+        }
+    }
+
+    public function testGetStringFromEnvironment(): void
+    {
+        putenv('OCE_SINCH_FAX_PROJECT_ID=test-project-123');
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertEquals(
+            'test-project-123',
+            $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID)
+        );
+    }
+
+    public function testGetBooleanTrueFromEnvironment(): void
+    {
+        putenv('OCE_SINCH_FAX_ENABLED=1');
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertTrue(
+            $accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED)
+        );
+    }
+
+    public function testGetBooleanFalseFromEnvironment(): void
+    {
+        putenv('OCE_SINCH_FAX_ENABLED=0');
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertFalse(
+            $accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED)
+        );
+    }
+
+    public function testGetBooleanTrueStringFromEnvironment(): void
+    {
+        putenv('OCE_SINCH_FAX_ENABLED=true');
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertTrue(
+            $accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED)
+        );
+    }
+
+    public function testGetIntFromEnvironment(): void
+    {
+        putenv('OCE_SINCH_FAX_DEFAULT_RETRY_COUNT=5');
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertEquals(
+            5,
+            $accessor->getInt(GlobalConfig::CONFIG_OPTION_DEFAULT_RETRY_COUNT)
+        );
+    }
+
+    public function testReturnsDefaultForUnsetVariable(): void
+    {
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertEquals(
+            'default-value',
+            $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID, 'default-value')
+        );
+    }
+
+    public function testReturnsDefaultBooleanForUnsetVariable(): void
+    {
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertFalse(
+            $accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED, false)
+        );
+    }
+
+    public function testReturnsDefaultIntForUnsetVariable(): void
+    {
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertEquals(
+            3,
+            $accessor->getInt(GlobalConfig::CONFIG_OPTION_DEFAULT_RETRY_COUNT, 3)
+        );
+    }
+
+    public function testHasReturnsTrueWhenSet(): void
+    {
+        putenv('OCE_SINCH_FAX_PROJECT_ID=test');
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertTrue(
+            $accessor->has(GlobalConfig::CONFIG_OPTION_PROJECT_ID)
+        );
+    }
+
+    public function testHasReturnsFalseWhenNotSet(): void
+    {
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertFalse(
+            $accessor->has(GlobalConfig::CONFIG_OPTION_PROJECT_ID)
+        );
+    }
+
+    public function testGetMapsAllConfigKeys(): void
+    {
+        $envVars = [
+            'OCE_SINCH_FAX_ENABLED' => '1',
+            'OCE_SINCH_FAX_PROJECT_ID' => 'proj-123',
+            'OCE_SINCH_FAX_SERVICE_ID' => 'svc-456',
+            'OCE_SINCH_FAX_AUTH_METHOD' => 'basic',
+            'OCE_SINCH_FAX_API_KEY' => 'key-789',
+            'OCE_SINCH_FAX_API_SECRET' => 'secret',
+            'OCE_SINCH_FAX_OAUTH_TOKEN' => 'token',
+            'OCE_SINCH_FAX_REGION' => 'use1',
+            'OCE_SINCH_FAX_FILE_STORAGE_PATH' => '/tmp/faxes',
+            'OCE_SINCH_FAX_DEFAULT_RETRY_COUNT' => '5',
+            'OCE_SINCH_FAX_WEBHOOK_USERNAME' => 'webhook_user',
+            'OCE_SINCH_FAX_WEBHOOK_PASSWORD' => 'webhook_pass',
+            'OCE_SINCH_FAX_WEBHOOK_IP_WHITELIST' => '10.0.0.1',
+        ];
+
+        foreach ($envVars as $key => $value) {
+            putenv("$key=$value");
+        }
+
+        $accessor = new EnvironmentConfigAccessor();
+
+        $this->assertTrue($accessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED));
+        $this->assertEquals('proj-123', $accessor->getString(GlobalConfig::CONFIG_OPTION_PROJECT_ID));
+        $this->assertEquals('svc-456', $accessor->getString(GlobalConfig::CONFIG_OPTION_SERVICE_ID));
+        $this->assertEquals('basic', $accessor->getString(GlobalConfig::CONFIG_OPTION_AUTH_METHOD));
+        $this->assertEquals('key-789', $accessor->getString(GlobalConfig::CONFIG_OPTION_API_KEY));
+        $this->assertEquals('secret', $accessor->getString(GlobalConfig::CONFIG_OPTION_API_SECRET));
+        $this->assertEquals('token', $accessor->getString(GlobalConfig::CONFIG_OPTION_OAUTH_TOKEN));
+        $this->assertEquals('use1', $accessor->getString(GlobalConfig::CONFIG_OPTION_REGION));
+        $this->assertEquals('/tmp/faxes', $accessor->getString(GlobalConfig::CONFIG_OPTION_FILE_STORAGE_PATH));
+        $this->assertEquals(5, $accessor->getInt(GlobalConfig::CONFIG_OPTION_DEFAULT_RETRY_COUNT));
+        $this->assertEquals('webhook_user', $accessor->getString(GlobalConfig::CONFIG_OPTION_WEBHOOK_USERNAME));
+        $this->assertEquals('webhook_pass', $accessor->getString(GlobalConfig::CONFIG_OPTION_WEBHOOK_PASSWORD));
+        $this->assertEquals('10.0.0.1', $accessor->getString(GlobalConfig::CONFIG_OPTION_WEBHOOK_IP_WHITELIST));
+    }
+}

--- a/tests/Unit/GlobalConfigTest.php
+++ b/tests/Unit/GlobalConfigTest.php
@@ -261,6 +261,17 @@ class GlobalConfigTest extends TestCase
         $this->assertEquals(['10.0.0.1', '192.168.1.0/24', '172.16.0.0/12'], $whitelist);
     }
 
+    public function testGetWebhookIpWhitelistParsesCommas(): void
+    {
+        $mockGlobals = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_WEBHOOK_IP_WHITELIST => "10.0.0.1, 192.168.1.0/24,172.16.0.0/12",
+        ]);
+        $config = new GlobalConfig($mockGlobals);
+
+        $whitelist = $config->getWebhookIpWhitelist();
+        $this->assertEquals(['10.0.0.1', '192.168.1.0/24', '172.16.0.0/12'], $whitelist);
+    }
+
     public function testGetWebhookIpWhitelistEmptyReturnsEmptyArray(): void
     {
         $mockGlobals = new MockGlobalsAccessor([


### PR DESCRIPTION
## Summary
- Add support for configuring the module via environment variables instead of the OpenEMR globals UI
- When `OCE_SINCH_FAX_ENV_CONFIG=1` is set, all configuration is read from `OCE_SINCH_FAX_*` environment variables
- Secrets are stored as plaintext in env vars (appropriate for managed deployments)

## Test plan
- [x] Verify module works normally without `OCE_SINCH_FAX_ENV_CONFIG` set
- [x] Set `OCE_SINCH_FAX_ENV_CONFIG=1` with required env vars and verify:
  - [x] Admin > Globals shows "Configuration Managed Externally" message
  - [x] No editable config fields displayed
  - [x] Menu item visible without global_req check
  - [x] Fax functionality works with env var configuration
- [x] Run `composer run test` - all 211 tests pass

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/code)