### PR TITLE
feat: return 404 for all web requests when module not installed/enabled

### DIFF
--- a/public/contact.php
+++ b/public/contact.php
@@ -11,12 +11,24 @@
  */
 
 $sessionAllowWrite = true;
-require_once(__DIR__ . "/../../../../globals.php");
-require_once(__DIR__ . "/../../../../../library/classes/Document.class.php");
+
+// Load module autoloader before globals.php so our classes are available
+// even when OpenEMR hasn't bootstrapped the module (e.g., module not registered)
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../../../../globals.php';
+require_once __DIR__ . '/../../../../../library/classes/Document.class.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
 use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
+use OpenCoreEMR\Modules\SinchFax\ModuleAccessGuard;
+
+// Check if module is installed and enabled - return 404 if not
+$guardResponse = ModuleAccessGuard::check(Bootstrap::MODULE_NAME);
+if ($guardResponse !== null) {
+    $guardResponse->send();
+    exit;
+}
 
 // Get kernel and bootstrap module
 $globalsAccessor = new GlobalsAccessor();

--- a/public/download.php
+++ b/public/download.php
@@ -10,6 +10,9 @@
  * @license   GNU General Public License 3
  */
 
+// Load module autoloader before globals.php so our classes are available
+// even when OpenEMR hasn't bootstrapped the module (e.g., module not registered)
+require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
@@ -17,7 +20,15 @@ use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxExceptionInterface;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxValidationException;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
+use OpenCoreEMR\Modules\SinchFax\ModuleAccessGuard;
 use Symfony\Component\HttpFoundation\Response;
+
+// Check if module is installed and enabled - return 404 if not
+$guardResponse = ModuleAccessGuard::check(Bootstrap::MODULE_NAME);
+if ($guardResponse !== null) {
+    $guardResponse->send();
+    exit;
+}
 
 // Get kernel and bootstrap module
 $globalsAccessor = new GlobalsAccessor();

--- a/public/index.php
+++ b/public/index.php
@@ -11,11 +11,23 @@
  */
 
 $sessionAllowWrite = true;
+
+// Load module autoloader before globals.php so our classes are available
+// even when OpenEMR hasn't bootstrapped the module (e.g., module not registered)
+require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
 use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
+use OpenCoreEMR\Modules\SinchFax\ModuleAccessGuard;
+
+// Check if module is installed and enabled - return 404 if not
+$guardResponse = ModuleAccessGuard::check(Bootstrap::MODULE_NAME);
+if ($guardResponse !== null) {
+    $guardResponse->send();
+    exit;
+}
 
 // Get kernel and bootstrap module
 $globalsAccessor = new GlobalsAccessor();

--- a/public/webhook.php
+++ b/public/webhook.php
@@ -15,14 +15,26 @@
 
 // Don't require session for webhooks - Sinch calls this endpoint directly
 $ignoreAuth = true;
+
+// Load module autoloader before globals.php so our classes are available
+// even when OpenEMR hasn't bootstrapped the module (e.g., module not registered)
+require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../../../../globals.php';
 
 use OpenCoreEMR\Modules\SinchFax\Bootstrap;
+use OpenCoreEMR\Modules\SinchFax\ModuleAccessGuard;
 use OpenCoreEMR\Modules\SinchFax\ConfigFactory;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxExceptionInterface;
 use OpenCoreEMR\Modules\SinchFax\GlobalsAccessor;
 use OpenEMR\Common\Logging\SystemLogger;
 use Symfony\Component\HttpFoundation\Response;
+
+// Check if module is installed and enabled - return 404 if not
+$guardResponse = ModuleAccessGuard::check(Bootstrap::MODULE_NAME);
+if ($guardResponse !== null) {
+    $guardResponse->send();
+    exit;
+}
 
 $logger = new SystemLogger();
 

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -142,6 +142,10 @@ class Bootstrap
 
     public function addSinchFaxMenuItem(MenuEvent $event): void
     {
+        if (!$this->globalsConfig->isEnabled()) {
+            return;
+        }
+
         $menu = $event->getMenu();
 
         $menuItem = new \stdClass();
@@ -153,11 +157,6 @@ class Bootstrap
         $menuItem->icon = 'fa-fax';
         $menuItem->children = [];
         $menuItem->acl_req = ["patients", "demo"];
-
-        // In env config mode, skip global_req check (menu always visible when module is enabled)
-        if (!$this->globalsConfig->isEnvConfigMode()) {
-            $menuItem->global_req = ["oce_sinch_fax_enabled"];
-        }
 
         foreach ($menu as $item) {
             if ($item->menu_id == 'modimg') {

--- a/src/EnvironmentConfigAccessor.php
+++ b/src/EnvironmentConfigAccessor.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  * bypassing the database-backed globals system entirely for module config.
  * OpenEMR system values (OE_SITE_DIR, webroot, etc.) are still delegated
  * to GlobalsAccessor since they are not module configuration.
+ *
+ * @internal Use ConfigFactory::createConfigAccessor() instead of instantiating directly
  */
 class EnvironmentConfigAccessor implements ConfigAccessorInterface
 {

--- a/src/GlobalsAccessor.php
+++ b/src/GlobalsAccessor.php
@@ -16,6 +16,8 @@ namespace OpenCoreEMR\Modules\SinchFax;
  * Provides centralized access to OpenEMR globals.
  * This class serves as a single point of abstraction for globals access,
  * making it easier to update or refactor in the future.
+ *
+ * @internal Use ConfigFactory::createConfigAccessor() instead of instantiating directly
  */
 class GlobalsAccessor implements ConfigAccessorInterface
 {

--- a/src/ModuleAccessGuard.php
+++ b/src/ModuleAccessGuard.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Guards module web entry points from access when module is not installed/enabled
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax;
+
+use OpenEMR\Common\Database\QueryUtils;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Prevents access to module web endpoints when the module is not properly installed and enabled.
+ *
+ * This guard checks three conditions:
+ * 1. Module is registered in OpenEMR's modules table
+ * 2. Module is enabled in module management (mod_active = 1)
+ * 3. Module's own 'enabled' global setting is turned on
+ *
+ * If any condition fails, returns a 404 response to avoid leaking information
+ * about the module's presence.
+ */
+class ModuleAccessGuard
+{
+    /**
+     * Check if the module is accessible and return a 404 response if not.
+     *
+     * @param string $moduleDirectory The module directory name (e.g., 'oce-module-sinch-fax')
+     * @param ConfigAccessorInterface|null $configAccessor Optional config accessor for testing
+     * @param (callable(string): bool)|null $moduleActiveChecker Optional callable for testing
+     * @return Response|null Returns 404 Response if access denied, null if access allowed
+     */
+    public static function check(
+        string $moduleDirectory,
+        ?ConfigAccessorInterface $configAccessor = null,
+        ?callable $moduleActiveChecker = null
+    ): ?Response {
+        // Check module registration and enabled status in modules table
+        $isActive = $moduleActiveChecker !== null
+            ? $moduleActiveChecker($moduleDirectory)
+            : self::isModuleActive($moduleDirectory);
+
+        if (!$isActive) {
+            return self::createNotFoundResponse();
+        }
+
+        // Check module's own enabled setting (respects env config mode)
+        $configAccessor ??= ConfigFactory::createConfigAccessor();
+        if (!$configAccessor->getBoolean(GlobalConfig::CONFIG_OPTION_ENABLED, false)) {
+            return self::createNotFoundResponse();
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if module is registered and active in OpenEMR's modules table
+     */
+    private static function isModuleActive(string $moduleDirectory): bool
+    {
+        try {
+            $sql = "SELECT mod_active FROM modules WHERE mod_directory = ?";
+            $result = QueryUtils::fetchSingleValue($sql, 'mod_active', [$moduleDirectory]);
+
+            // Module not found or not active
+            if ($result === null || $result === false) {
+                return false;
+            }
+
+            // Check if active (mod_active = 1)
+            return (int) $result === 1;
+        } catch (\Throwable) {
+            // Database error - fail closed (deny access)
+            return false;
+        }
+    }
+
+    /**
+     * Create a 404 Not Found response
+     */
+    private static function createNotFoundResponse(): Response
+    {
+        return new Response('Not Found', Response::HTTP_NOT_FOUND, [
+            'Content-Type' => 'text/plain'
+        ]);
+    }
+}

--- a/tests/Unit/ModuleAccessGuardTest.php
+++ b/tests/Unit/ModuleAccessGuardTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Unit tests for ModuleAccessGuard
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax\Tests\Unit;
+
+use OpenCoreEMR\Modules\SinchFax\GlobalConfig;
+use OpenCoreEMR\Modules\SinchFax\ModuleAccessGuard;
+use OpenCoreEMR\Modules\SinchFax\Tests\Mocks\MockGlobalsAccessor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ModuleAccessGuardTest extends TestCase
+{
+    public function testReturnsNullWhenModuleActiveAndEnabled(): void
+    {
+        $configAccessor = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => true,
+        ]);
+
+        $result = ModuleAccessGuard::check(
+            'oce-module-sinch-fax',
+            $configAccessor,
+            fn() => true // Module is active in database
+        );
+
+        $this->assertNull($result);
+    }
+
+    public function testReturns404WhenModuleNotActiveInDatabase(): void
+    {
+        $configAccessor = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => true,
+        ]);
+
+        $result = ModuleAccessGuard::check(
+            'oce-module-sinch-fax',
+            $configAccessor,
+            fn() => false // Module not active in database
+        );
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $result->getStatusCode());
+        $this->assertEquals('Not Found', $result->getContent());
+    }
+
+    public function testReturns404WhenModuleNotEnabled(): void
+    {
+        $configAccessor = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => false,
+        ]);
+
+        $result = ModuleAccessGuard::check(
+            'oce-module-sinch-fax',
+            $configAccessor,
+            fn() => true // Module is active in database
+        );
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $result->getStatusCode());
+    }
+
+    public function testReturns404WhenModuleEnabledSettingMissing(): void
+    {
+        $configAccessor = new MockGlobalsAccessor([]);
+
+        $result = ModuleAccessGuard::check(
+            'oce-module-sinch-fax',
+            $configAccessor,
+            fn() => true // Module is active in database
+        );
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $result->getStatusCode());
+    }
+
+    public function testReturns404WhenBothConditionsFail(): void
+    {
+        $configAccessor = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => false,
+        ]);
+
+        $result = ModuleAccessGuard::check(
+            'oce-module-sinch-fax',
+            $configAccessor,
+            fn() => false // Module not active in database
+        );
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $result->getStatusCode());
+    }
+
+    public function testModuleDirectoryPassedToChecker(): void
+    {
+        $receivedDirectory = null;
+        $configAccessor = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => true,
+        ]);
+
+        ModuleAccessGuard::check(
+            'test-module-name',
+            $configAccessor,
+            function ($directory) use (&$receivedDirectory) {
+                $receivedDirectory = $directory;
+                return true;
+            }
+        );
+
+        $this->assertEquals('test-module-name', $receivedDirectory);
+    }
+
+    public function testResponseContentType(): void
+    {
+        $configAccessor = new MockGlobalsAccessor([
+            GlobalConfig::CONFIG_OPTION_ENABLED => false,
+        ]);
+
+        $result = ModuleAccessGuard::check(
+            'oce-module-sinch-fax',
+            $configAccessor,
+            fn() => true
+        );
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals('text/plain', $result->headers->get('Content-Type'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ModuleAccessGuard` class to check module installation/enabled status
- Guard all public entry points (`webhook.php`, `index.php`, `contact.php`, `download.php`)
- Return 404 instead of 500 errors when module isn't properly installed

Fixes #72

## Test plan
- [x] Verify 404 returned when module not registered in `modules` table
- [x] Verify 404 returned when module disabled (`mod_active = 0`)
- [x] Verify 404 returned when `oce_sinch_fax_enabled` setting is false
- [x] Verify normal operation when all conditions met

🤖 Generated with [Claude Code](https://claude.com/claude-code)