### PR TITLE
fix: move dlgclose script from controller echo to template

### DIFF
--- a/src/Controller/DocumentFaxController.php
+++ b/src/Controller/DocumentFaxController.php
@@ -168,9 +168,6 @@ class DocumentFaxController
                             unlink($tempFileWithExt);
 
                             $success = xlt("Fax sent successfully");
-
-                            // Close dialog after success
-                            echo "<script>setTimeout(function() { dlgclose(); }, 2000);</script>";
                         }
                     } catch (\Throwable $e) {
                         $error = xlt("Error retrieving document") . ": " . text($e->getMessage());

--- a/templates/fax/send-document.html.twig
+++ b/templates/fax/send-document.html.twig
@@ -32,6 +32,7 @@
             <div class="alert alert-success" role="alert">
                 {{ success_message|raw }}
             </div>
+            <script>setTimeout(function() { dlgclose(); }, 2000);</script>
         {% endif %}
 
         <form method="post" id="fax-form">


### PR DESCRIPTION
## Summary
- Move dialog close script from `echo` in DocumentFaxController to Twig template
- Prevents raw `<script>` tags from appearing in test output

## Test plan
- [ ] Verify fax send dialog still closes after successful send
- [x] Verify test output is clean (no script tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)