### PR TITLE
fix: remove auto-enabled coverage config from phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,14 +24,4 @@
             <directory>src/Exception</directory>
         </exclude>
     </source>
-
-    <coverage includeUncoveredFiles="true"
-              pathCoverage="false"
-              ignoreDeprecatedCodeUnits="true"
-              disableCodeCoverageIgnore="true">
-        <report>
-            <html outputDirectory="htmlcov" lowUpperBound="50" highLowerBound="80"/>
-            <text outputFile="php://stdout" showUncoveredFiles="false"/>
-        </report>
-    </coverage>
 </phpunit>


### PR DESCRIPTION
## Summary

Remove the `<coverage>` section from phpunit.xml but keep `<source>` section.

- `<source>` defines what files to analyze for coverage (needed for CI)
- `<coverage>` auto-enables report generation (removed - should be enabled via CLI flags when needed)

Coverage should be enabled via command line flags (`--coverage-html`) when needed, not permanently configured on.

## Test plan

- [x] Run `task test` locally - should complete without PHPUnit warnings
- [x] CI tests with coverage should still work (uses `--coverage-*` flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)