### PR TITLE
refactor(exceptions): replace generic \Exception with custom exception types

### DIFF
--- a/docs/development/exceptions.md
+++ b/docs/development/exceptions.md
@@ -1,5 +1,27 @@
 # Exception Handling Pattern
 
+## Design Principle: Always Use Custom Exceptions
+
+**CRITICAL: Never throw `\Exception`, `\RuntimeException`, or other generic PHP exceptions directly.**
+
+Always use module-specific exception types from `src/Exception/`. This ensures:
+- All module errors are easily identifiable and catchable
+- Consistent HTTP status codes via `getStatusCode()`
+- Clear error categorization for logging and debugging
+
+**Never do:**
+```php
+throw new \Exception("Something went wrong");  // BAD - generic exception
+throw new \RuntimeException("API failed");     // BAD - not module-specific
+```
+
+**Always do:**
+```php
+throw new FaxApiException("Sinch API returned invalid JSON");
+throw new FaxNotFoundException("Fax not found");
+throw new FaxValidationException("Invalid phone number format");
+```
+
 ## Error Handling Best Practice: Always Catch `\Throwable`
 
 **CRITICAL: Always catch `\Throwable` instead of `\Exception`**
@@ -79,6 +101,7 @@ class {Module}NotFoundException extends {Module}Exception
 - `{Module}AccessDeniedException` (403) - CSRF failed, insufficient permissions
 - `{Module}ValidationException` (400) - Invalid input data
 - `{Module}ConfigurationException` (500) - Configuration errors
+- `{Module}ApiException` (502) - External API communication errors
 
 ## Exception Handling in Public Files
 

--- a/src/Client/SinchFaxClient.php
+++ b/src/Client/SinchFaxClient.php
@@ -14,6 +14,8 @@ namespace OpenCoreEMR\Modules\SinchFax\Client;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use OpenCoreEMR\Modules\SinchFax\Exception\FaxApiException;
+use OpenCoreEMR\Modules\SinchFax\Exception\FaxValidationException;
 use OpenCoreEMR\Modules\SinchFax\GlobalConfig;
 use OpenEMR\Common\Logging\SystemLogger;
 
@@ -74,7 +76,7 @@ class SinchFaxClient
      *
      * @param array<string, mixed> $params Fax parameters
      * @return array<string, mixed> Response from API
-     * @throws \Exception
+     * @throws FaxValidationException|FaxApiException
      */
     public function sendFax(array $params): array
     {
@@ -99,7 +101,7 @@ class SinchFaxClient
                     // Suppress warning - we check return value and throw exception
                     $fileContents = @file_get_contents($filePath);
                     if ($fileContents === false) {
-                        throw new \Exception('Failed to read file: ' . $filePath);
+                        throw new FaxValidationException('Failed to read file: ' . $filePath);
                     }
 
                     // Debug: Check file header to verify it's not encrypted
@@ -191,7 +193,7 @@ class SinchFaxClient
             $this->logger->debug("Sinch Fax API Response: " . $body);
             $decoded = json_decode($body, true);
             if (!is_array($decoded)) {
-                throw new \Exception('Invalid JSON response from Sinch API');
+                throw new FaxApiException('Invalid JSON response from Sinch API');
             }
             /** @var array<string, mixed> $decoded */
             return $decoded;
@@ -202,7 +204,7 @@ class SinchFaxClient
                 $responseBody = $e->getResponse()->getBody()->getContents();
                 $this->logger->error('Sinch API Response Body: ' . $responseBody);
             }
-            throw new \Exception('Failed to send fax: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to send fax: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -210,7 +212,7 @@ class SinchFaxClient
      * Get fax details
      *
      * @return array<string, mixed>
-     * @throws \Exception
+     * @throws FaxApiException
      */
     public function getFax(string $faxId): array
     {
@@ -222,13 +224,13 @@ class SinchFaxClient
             $body = $response->getBody()->getContents();
             $decoded = json_decode($body, true);
             if (!is_array($decoded)) {
-                throw new \Exception('Invalid JSON response from Sinch API');
+                throw new FaxApiException('Invalid JSON response from Sinch API');
             }
             /** @var array<string, mixed> $decoded */
             return $decoded;
         } catch (GuzzleException $e) {
             $this->logger->error('Sinch Fax API error: ' . $e->getMessage());
-            throw new \Exception('Failed to get fax: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to get fax: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -237,7 +239,7 @@ class SinchFaxClient
      *
      * @param array<string, mixed> $filters Optional filters
      * @return array<string, mixed>
-     * @throws \Exception
+     * @throws FaxApiException
      */
     public function listFaxes(array $filters = []): array
     {
@@ -284,13 +286,13 @@ class SinchFaxClient
             $body = $response->getBody()->getContents();
             $decoded = json_decode($body, true);
             if (!is_array($decoded)) {
-                throw new \Exception('Invalid JSON response from Sinch API');
+                throw new FaxApiException('Invalid JSON response from Sinch API');
             }
             /** @var array<string, mixed> $decoded */
             return $decoded;
         } catch (GuzzleException $e) {
             $this->logger->error('Sinch Fax API error: ' . $e->getMessage());
-            throw new \Exception('Failed to list faxes: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to list faxes: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -298,7 +300,7 @@ class SinchFaxClient
      * Download fax content
      *
      * @return string Binary content of the fax
-     * @throws \Exception
+     * @throws FaxApiException
      */
     public function downloadFax(string $faxId): string
     {
@@ -310,14 +312,14 @@ class SinchFaxClient
             return $response->getBody()->getContents();
         } catch (GuzzleException $e) {
             $this->logger->error('Sinch Fax API error: ' . $e->getMessage());
-            throw new \Exception('Failed to download fax: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to download fax: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
     /**
      * Delete a fax
      *
-     * @throws \Exception
+     * @throws FaxApiException
      */
     public function deleteFax(string $faxId): bool
     {
@@ -328,7 +330,7 @@ class SinchFaxClient
             return true;
         } catch (GuzzleException $e) {
             $this->logger->error('Sinch Fax API error: ' . $e->getMessage());
-            throw new \Exception('Failed to delete fax: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to delete fax: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -336,7 +338,7 @@ class SinchFaxClient
      * List all fax services for the project
      *
      * @return array<string, mixed> Response containing services array
-     * @throws \Exception
+     * @throws FaxApiException
      */
     public function listServices(): array
     {
@@ -348,13 +350,13 @@ class SinchFaxClient
             $body = $response->getBody()->getContents();
             $decoded = json_decode($body, true);
             if (!is_array($decoded)) {
-                throw new \Exception('Invalid JSON response from Sinch API');
+                throw new FaxApiException('Invalid JSON response from Sinch API');
             }
             /** @var array<string, mixed> $decoded */
             return $decoded;
         } catch (GuzzleException $e) {
             $this->logger->error('Sinch Fax API error: ' . $e->getMessage());
-            throw new \Exception('Failed to list services: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to list services: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -363,7 +365,7 @@ class SinchFaxClient
      *
      * @param string $serviceId The service ID
      * @return array<string, mixed> Response containing numbers array
-     * @throws \Exception
+     * @throws FaxApiException
      */
     public function listServiceNumbers(string $serviceId): array
     {
@@ -375,13 +377,13 @@ class SinchFaxClient
             $body = $response->getBody()->getContents();
             $decoded = json_decode($body, true);
             if (!is_array($decoded)) {
-                throw new \Exception('Invalid JSON response from Sinch API');
+                throw new FaxApiException('Invalid JSON response from Sinch API');
             }
             /** @var array<string, mixed> $decoded */
             return $decoded;
         } catch (GuzzleException $e) {
             $this->logger->error('Sinch Fax API error: ' . $e->getMessage());
-            throw new \Exception('Failed to list service numbers: ' . $e->getMessage(), $e->getCode(), $e);
+            throw new FaxApiException('Failed to list service numbers: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 }

--- a/src/Exception/FaxApiException.php
+++ b/src/Exception/FaxApiException.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Exception thrown when Sinch API communication fails
+ *
+ * @package   OpenCoreEMR
+ * @link      https://opencoreemr.com
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   GNU General Public License 3
+ */
+
+namespace OpenCoreEMR\Modules\SinchFax\Exception;
+
+class FaxApiException extends FaxException
+{
+    public function getStatusCode(): int
+    {
+        return 502;
+    }
+}

--- a/src/Service/FaxService.php
+++ b/src/Service/FaxService.php
@@ -13,6 +13,9 @@
 namespace OpenCoreEMR\Modules\SinchFax\Service;
 
 use OpenCoreEMR\Modules\SinchFax\Client\SinchFaxClient;
+use OpenCoreEMR\Modules\SinchFax\Exception\FaxConfigurationException;
+use OpenCoreEMR\Modules\SinchFax\Exception\FaxNotFoundException;
+use OpenCoreEMR\Modules\SinchFax\Exception\FaxValidationException;
 use OpenCoreEMR\Modules\SinchFax\GlobalConfig;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -403,7 +406,7 @@ class FaxService
      * Get or create "Received Faxes" category
      *
      * @return int Category ID
-     * @throws \Exception
+     * @throws FaxConfigurationException
      */
     private function getReceivedFaxesCategoryId(): int
     {
@@ -423,7 +426,7 @@ class FaxService
         $category = QueryUtils::querySingleRow($sql, ['Received Faxes']);
 
         if (!$category) {
-            throw new \Exception("Failed to create 'Received Faxes' category");
+            throw new FaxConfigurationException("Failed to create 'Received Faxes' category");
         }
 
         $this->logger->info("Created 'Received Faxes' document category");
@@ -598,7 +601,7 @@ class FaxService
      * @param int $faxId Internal fax database ID
      * @param int $patientId Patient ID
      * @return int Created document ID
-     * @throws \Exception
+     * @throws FaxNotFoundException|FaxValidationException|FaxConfigurationException
      */
     public function moveToPatientDocuments(int $faxId, int $patientId): int
     {
@@ -606,20 +609,22 @@ class FaxService
         $fax = QueryUtils::querySingleRow($faxSql, [$faxId]);
 
         if (!$fax) {
-            throw new \Exception("Fax not found");
+            throw new FaxNotFoundException("Fax not found");
         }
 
         if ($fax['document_id']) {
-            throw new \Exception("Fax has already been moved to patient chart (Document ID: {$fax['document_id']})");
+            throw new FaxValidationException(
+                "Fax has already been moved to patient chart (Document ID: {$fax['document_id']})"
+            );
         }
 
         if (empty($fax['file_path']) || !file_exists($fax['file_path'])) {
-            throw new \Exception("Fax file not found");
+            throw new FaxNotFoundException("Fax file not found");
         }
 
         $fileContents = file_get_contents($fax['file_path']);
         if ($fileContents === false) {
-            throw new \Exception("Unable to read fax file");
+            throw new FaxValidationException("Unable to read fax file");
         }
 
         $filename = basename((string) $fax['file_path']);
@@ -642,7 +647,7 @@ class FaxService
         );
 
         if (!empty($result)) {
-            throw new \Exception("Failed to create document: " . $result);
+            throw new FaxConfigurationException("Failed to create document: " . $result);
         }
 
         $documentId = $document->get_id();


### PR DESCRIPTION
## Summary
- Enforces design principle: always use custom exceptions instead of generic `\Exception`
- Adds explicit documentation of this principle in exceptions.md
- Creates `FaxApiException` for Sinch API communication errors

## Changes proposed in this pull request
- Add `FaxApiException` class for API/Guzzle errors (returns 502 status)
- Replace 18 instances of `throw new \Exception` with appropriate custom types:
  - `FaxApiException` for Sinch API failures
  - `FaxValidationException` for input validation errors  
  - `FaxNotFoundException` for missing faxes/files
  - `FaxConfigurationException` for system setup errors
- Update `docs/development/exceptions.md` with explicit "never throw generic exceptions" rule
- Update `@throws` docblocks to reflect actual exception types

## AI Disclosure
Yes

🤖 Generated with [Claude Code](https://claude.ai/code)