### PR TITLE
ci: grant conventional-pr-title workflow pull-requests:read

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+
 jobs:
   conventional-pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit `permissions: pull-requests: read` block to `.github/workflows/conventional-pr-title.yml`. Without it, amannn/action-semantic-pull-request fails with "Resource not accessible by integration" because the org's default GITHUB_TOKEN permissions are restricted.