### PR TITLE
feat!: drop PHP < 8.5, fix failing Rector on main

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2, composer-require-checker

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2

--- a/.github/workflows/openemr-compat.yml
+++ b/.github/workflows/openemr-compat.yml
@@ -50,10 +50,10 @@ jobs:
       working-directory: openemr
       run: composer config repositories.sinch-fax path ../module
 
-    - name: Use runner PHP version for resolution
-      working-directory: openemr
-      run: composer config --unset platform.php
-
+    # Ignore the PHP platform requirement during resolution. OpenEMR's
+    # composer.json pins config.platform.php to an older version, which
+    # would conflict with this module's >=8.5 floor. This check is about
+    # non-PHP package compatibility; PHP version is enforced separately.
     - name: Require module (dry-run)
       working-directory: openemr
-      run: composer require --dry-run --no-interaction opencoreemr/oce-module-sinch-fax:@dev
+      run: composer require --dry-run --no-interaction --ignore-platform-req=php opencoreemr/oce-module-sinch-fax:@dev

--- a/.github/workflows/openemr-compat.yml
+++ b/.github/workflows/openemr-compat.yml
@@ -50,6 +50,10 @@ jobs:
       working-directory: openemr
       run: composer config repositories.sinch-fax path ../module
 
+    - name: Use runner PHP version for resolution
+      working-directory: openemr
+      run: composer config --unset platform.php
+
     - name: Require module (dry-run)
       working-directory: openemr
       run: composer require --dry-run --no-interaction opencoreemr/oce-module-sinch-fax:@dev

--- a/.github/workflows/openemr-compat.yml
+++ b/.github/workflows/openemr-compat.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: curl, json, mbstring, sodium, xml, gd
         coverage: none
         tools: composer:v2

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.2'
+        php-version: '8.5'
         extensions: json, curl
         coverage: none
         tools: composer:v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-        - '8.2'
-        - '8.3'
-        - '8.4'
         - '8.5'
 
     steps:
@@ -52,19 +49,13 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-interaction
 
-    - name: Run tests
-      if: matrix.php-version != '8.2'
-      run: composer test
-
     - name: Run tests with coverage
-      if: matrix.php-version == '8.2'
       run: |
         echo "::group::Running PHPUnit with Coverage"
         vendor/bin/phpunit --coverage-text --coverage-html coverage-report --colors=never
         echo "::endgroup::"
 
     - name: Upload coverage report
-      if: matrix.php-version == '8.2'
       uses: actions/upload-artifact@v7
       with:
         name: coverage-report

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -255,7 +255,7 @@ This project uses pre-commit hooks to enforce code quality standards. The hooks 
 - **PHP Syntax Check** - Validates PHP syntax
 - **PHP CodeSniffer** - Enforces PSR-12 coding standards
 - **PHPStan** - Static analysis (level 8)
-- **Rector** - PHP 8.2+ compatibility checks
+- **Rector** - PHP 8.5+ compatibility checks
 
 To run checks manually:
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A secure fax integration module for OpenEMR using the Sinch Fax API.
 ## Requirements
 
 - OpenEMR 7.0.0 or later
-- PHP 8.2 or later
+- PHP 8.5 or later
 - MySQL 5.7 or later / MariaDB 10.2 or later
 - Sinch Fax account with API credentials
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "source": "https://github.com/opencoreemr/oce-module-sinch-fax"
   },
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.5",
     "ext-curl": "*",
     "ext-date": "*",
     "ext-filter": "*",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,7 +25,7 @@
     <rule ref="PSR12"/>
 
     <!-- PHP version compatibility -->
-    <config name="testVersion" value="8.2-"/>
+    <config name="testVersion" value="8.5-"/>
 
     <!-- Additional rules -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,7 @@ parameters:
         - version.php
 
     # PHP version
-    phpVersion: 80200
+    phpVersion: 80500
 
     # Ignore errors in vendor
     excludePaths:

--- a/src/ConfigAccessorInterface.php
+++ b/src/ConfigAccessorInterface.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax;
 
 /**

--- a/src/Console/Command/AbstractModuleCommand.php
+++ b/src/Console/Command/AbstractModuleCommand.php
@@ -12,6 +12,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use OpenCoreEMR\Modules\SinchFax\Console\ModuleInstaller;

--- a/src/Console/Command/ModuleDisableCommand.php
+++ b/src/Console/Command/ModuleDisableCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/Command/ModuleEnableCommand.php
+++ b/src/Console/Command/ModuleEnableCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/Command/ModuleInstallCommand.php
+++ b/src/Console/Command/ModuleInstallCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/Command/ModuleInstallEnableCommand.php
+++ b/src/Console/Command/ModuleInstallEnableCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/Command/ModuleListCommand.php
+++ b/src/Console/Command/ModuleListCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/Command/ModuleRegisterCommand.php
+++ b/src/Console/Command/ModuleRegisterCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Console/Command/ModuleUnregisterCommand.php
+++ b/src/Console/Command/ModuleUnregisterCommand.php
@@ -10,6 +10,8 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Controller/FaxDownloadController.php
+++ b/src/Controller/FaxDownloadController.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Controller;
 
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxAccessDeniedException;

--- a/src/Controller/FaxListController.php
+++ b/src/Controller/FaxListController.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Controller;
 
 use OpenCoreEMR\Modules\SinchFax\Service\FaxService;

--- a/src/Exception/FaxAccessDeniedException.php
+++ b/src/Exception/FaxAccessDeniedException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 class FaxAccessDeniedException extends FaxException

--- a/src/Exception/FaxApiException.php
+++ b/src/Exception/FaxApiException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 class FaxApiException extends FaxException

--- a/src/Exception/FaxConfigurationException.php
+++ b/src/Exception/FaxConfigurationException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 class FaxConfigurationException extends FaxException

--- a/src/Exception/FaxException.php
+++ b/src/Exception/FaxException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 abstract class FaxException extends \RuntimeException implements FaxExceptionInterface

--- a/src/Exception/FaxExceptionInterface.php
+++ b/src/Exception/FaxExceptionInterface.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 interface FaxExceptionInterface extends \Throwable

--- a/src/Exception/FaxNotFoundException.php
+++ b/src/Exception/FaxNotFoundException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 class FaxNotFoundException extends FaxException

--- a/src/Exception/FaxUnauthorizedException.php
+++ b/src/Exception/FaxUnauthorizedException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 class FaxUnauthorizedException extends FaxException

--- a/src/Exception/FaxValidationException.php
+++ b/src/Exception/FaxValidationException.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax\Exception;
 
 class FaxValidationException extends FaxException

--- a/src/GlobalsAccessor.php
+++ b/src/GlobalsAccessor.php
@@ -10,6 +10,8 @@
  * @license   GNU General Public License 3
  */
 
+declare(strict_types=1);
+
 namespace OpenCoreEMR\Modules\SinchFax;
 
 /**

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,8 +85,8 @@ These mocks ensure tests run quickly and don't require a full OpenEMR installati
 
 Tests are automatically run on every push and pull request via GitHub Actions. The workflow:
 
-- Runs tests on PHP 8.2, 8.3, and 8.4
-- Generates code coverage report (PHP 8.3 only)
+- Runs tests on PHP 8.5
+- Generates code coverage report
 - Runs code quality checks (PHPStan, PHP_CodeSniffer, Rector)
 
 See `.github/workflows/tests.yml` for the complete configuration.
@@ -178,6 +178,6 @@ Exception classes are excluded from coverage requirements as they are simple dat
 The test suite runs automatically on GitHub Actions for:
 - Every push to `main`, `develop`, or feature branches
 - Every pull request
-- Multiple PHP versions (8.2, 8.3, 8.4)
+- PHP 8.5
 
 Pull requests must pass all tests before being merged.


### PR DESCRIPTION
## Summary

- Fix the failing Rector check on `main` by applying `SafeDeclareStrictTypesRector` across all 20 `src/` files (PSR-12 header order: docblock → declare → namespace).
- Drop support for PHP 8.2, 8.3, and 8.4. Minimum is now PHP 8.5.

Touches `composer.json`, `rector.php` (`PHP_85`), `phpstan.neon` (`80500`), `phpcs.xml` (`testVersion 8.5-`), all single-version workflows, and collapses the `tests.yml` matrix to 8.5. README/DEVELOPMENT/tests README updated to match.

**BREAKING CHANGE:** Minimum required PHP version is now 8.5.

## Test plan

- [ ] Rector workflow passes
- [ ] PHPStan workflow passes
- [ ] PHPCS workflow passes
- [ ] Tests workflow passes on 8.5
- [ ] OpenEMR compat workflow passes against `v8_0_0`, `rel-800`, and `master`