### PR TITLE
ci: migrate to reusable PHP CI workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,12 +14,4 @@ on:
 
 jobs:
   actionlint:
-    name: Lint GitHub Actions workflows
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Run actionlint
-      uses: rhysd/actionlint@v1.7.12
+    uses: openCoreEMR/github-workflows-public/.github/workflows/actionlint.yml@0.0.2

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
     - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-normalize.yml
   pull_request:
     branches:
     - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-normalize.yml
 
 jobs:
   composer-normalize:

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -10,31 +10,8 @@ on:
 
 jobs:
   composer-normalize:
-    name: Normalize composer.json (check)
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Normalize composer.json (check)
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: Normalize composer.json (check)
       run: composer normalize --dry-run
+      php-version: '8.5'

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -4,9 +4,21 @@ on:
   push:
     branches:
     - main
+    paths:
+    - composer.json
+    - composer.lock
+    - '**.php'
+    - .composer-require-checker.json
+    - .github/workflows/composer-require-checker.yml
   pull_request:
     branches:
     - main
+    paths:
+    - composer.json
+    - composer.lock
+    - '**.php'
+    - .composer-require-checker.json
+    - .github/workflows/composer-require-checker.yml
 
 jobs:
   composer-require-checker:

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -10,31 +10,9 @@ on:
 
 jobs:
   composer-require-checker:
-    name: Run Composer Require Checker
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2, composer-require-checker
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run Composer Require Checker
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: Run Composer Require Checker
       run: composer-require-checker check --config-file=.composer-require-checker.json
+      php-tools: 'composer:v2, composer-require-checker'
+      php-version: '8.5'

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
     - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-validate.yml
   pull_request:
     branches:
     - main
+    paths:
+    - composer.json
+    - .github/workflows/composer-validate.yml
 
 jobs:
   composer-validate:

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -10,20 +10,9 @@ on:
 
 jobs:
   composer-validate:
-    name: Validate composer.json
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2
-
-    - name: Validate composer.json
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: Validate composer.json
       run: composer validate --strict
+      install-deps: false
+      php-version: '8.5'

--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -4,33 +4,6 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  pull-requests: read
-
 jobs:
   conventional-pr-title:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: amannn/action-semantic-pull-request@v6
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        types: |
-          feat
-          fix
-          docs
-          style
-          refactor
-          perf
-          test
-          build
-          ci
-          chore
-          revert
-          deps
-        requireScope: false
-        subjectPattern: ^(?![A-Z]).+$
-        subjectPatternError: |
-          The subject "{subject}" found in the pull request title "{title}"
-          didn't match the configured pattern. Please ensure that the subject
-          doesn't start with an uppercase character.
+    uses: openCoreEMR/github-workflows-public/.github/workflows/conventional-pr-title.yml@0.0.2

--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -4,9 +4,21 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**/compose.yml'
+    - '**/compose.yaml'
+    - '**/docker-compose*.yml'
+    - '**/docker-compose*.yaml'
+    - .github/workflows/dclint.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**/compose.yml'
+    - '**/compose.yaml'
+    - '**/docker-compose*.yml'
+    - '**/docker-compose*.yaml'
+    - .github/workflows/dclint.yml
 
 jobs:
   dclint:

--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -4,45 +4,10 @@ on:
   push:
     branches:
     - main
-    paths:
-    - '**/docker-compose*.yml'
-    - '**/docker-compose*.yaml'
-    - compose.yml
-    - compose.yaml
   pull_request:
     branches:
     - main
-    paths:
-    - '**/docker-compose*.yml'
-    - '**/docker-compose*.yaml'
-    - compose.yml
-    - compose.yaml
 
 jobs:
   dclint:
-    name: Lint Docker Compose files
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20'
-
-    - name: Install dclint
-      run: npm install -g dclint
-
-    - name: Run dclint
-      run: |
-        git ls-files -z 'compose.yml' \
-                        'compose.yaml' \
-                        'docker-compose*.yml' \
-                        'docker-compose*.yaml' \
-                        '**/compose.yml' \
-                        '**/compose.yaml' \
-                        '**/docker-compose*.yml' \
-                        '**/docker-compose*.yaml' |
-        xargs --null --no-run-if-empty dclint
+    uses: openCoreEMR/github-workflows-public/.github/workflows/dclint.yml@0.0.2

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**/Dockerfile*'
+    - .github/workflows/hadolint.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**/Dockerfile*'
+    - .github/workflows/hadolint.yml
 
 jobs:
   hadolint:

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -4,26 +4,10 @@ on:
   push:
     branches:
     - main
-    paths:
-    - '**/Dockerfile*'
   pull_request:
     branches:
     - main
-    paths:
-    - '**/Dockerfile*'
 
 jobs:
   hadolint:
-    name: Lint Dockerfiles
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Run hadolint
-      run: |
-        git ls-files -z 'Dockerfile*' \
-                        '**/Dockerfile*' |
-        xargs --null --no-run-if-empty --replace={} \
-          docker run --rm -v "$PWD:/workdir" -w /workdir hadolint/hadolint hadolint "{}"
+    uses: openCoreEMR/github-workflows-public/.github/workflows/hadolint.yml@0.0.2

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - .github/workflows/php-syntax-check.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - .github/workflows/php-syntax-check.yml
 
 jobs:
   php-syntax-check:

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -10,20 +10,9 @@ on:
 
 jobs:
   php-syntax-check:
-    name: PHP Syntax Check
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2
-
-    - name: PHP Syntax Check
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: PHP Syntax Check
       run: composer php-lint
+      install-deps: false
+      php-version: '8.5'

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - '.phpcs.xml*'
+    - 'phpcs.xml*'
+    - .github/workflows/phpcs.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - '.phpcs.xml*'
+    - 'phpcs.xml*'
+    - .github/workflows/phpcs.yml
 
 jobs:
   phpcs:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -10,31 +10,8 @@ on:
 
 jobs:
   phpcs:
-    name: Run PHP CodeSniffer
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run PHP CodeSniffer
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: Run PHP CodeSniffer
       run: composer phpcs
+      php-version: '8.5'

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,9 +4,25 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - phpstan.neon
+    - phpstan.neon.dist
+    - phpstan-baseline.neon
+    - composer.json
+    - composer.lock
+    - .github/workflows/phpstan.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - phpstan.neon
+    - phpstan.neon.dist
+    - phpstan-baseline.neon
+    - composer.json
+    - composer.lock
+    - .github/workflows/phpstan.yml
 
 jobs:
   phpstan:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,31 +10,8 @@ on:
 
 jobs:
   phpstan:
-    name: Run PHPStan
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run PHPStan
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: Run PHPStan
       run: composer phpstan
+      php-version: '8.5'

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -4,9 +4,21 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - rector.php
+    - composer.json
+    - composer.lock
+    - .github/workflows/rector.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - rector.php
+    - composer.json
+    - composer.lock
+    - .github/workflows/rector.yml
 
 jobs:
   rector:

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -10,31 +10,8 @@ on:
 
 jobs:
   rector:
-    name: Run Rector (dry-run)
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '8.5'
-        extensions: json, curl
-        coverage: none
-        tools: composer:v2
-
-    - name: Cache Composer dependencies
-      uses: actions/cache@v5
-      with:
-        path: vendor
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run Rector (dry-run)
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    with:
+      name: Run Rector (dry-run)
       run: composer rector
+      php-version: '8.5'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,23 @@ on:
   push:
     branches:
     - main
+    paths:
+    - '**.php'
+    - composer.json
+    - composer.lock
+    - phpunit.xml
+    - phpunit.xml.dist
+    - .github/workflows/tests.yml
   pull_request:
     branches:
     - main
+    paths:
+    - '**.php'
+    - composer.json
+    - composer.lock
+    - phpunit.xml
+    - phpunit.xml.dist
+    - .github/workflows/tests.yml
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,54 +10,7 @@ on:
 
 jobs:
   test:
-    name: PHP ${{ matrix.php-version }} Tests
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version:
-        - '8.5'
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-version }}
-        extensions: curl, json, mbstring
-        coverage: xdebug
-        tools: composer:v2
-
-    - name: Get composer cache directory
-      id: composer-cache
-      run: |
-        {
-          printf dir=
-          composer config cache-files-dir
-        } > "$GITHUB_OUTPUT"
-
-    - name: Cache dependencies
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
-
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Run tests with coverage
-      run: |
-        echo "::group::Running PHPUnit with Coverage"
-        vendor/bin/phpunit --coverage-text --coverage-html coverage-report --colors=never
-        echo "::endgroup::"
-
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v7
-      with:
-        name: coverage-report
-        path: coverage-report/
-        retention-days: 14
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-tests.yml@0.0.2
+    with:
+      php-versions: '["8.5"]'
+      coverage-php-version: '8.5'


### PR DESCRIPTION
## Summary

Migration to the reusable PHP CI workflows in [`openCoreEMR/github-workflows-public@0.0.2`](https://github.com/openCoreEMR/github-workflows-public/releases/tag/0.0.2). Replaces the inlined workflows with thin callers.

Same pattern as the pilot: openCoreEMR/oce-lib-module-config#13. This repo also uses the dclint and hadolint reusables. `openemr-compat.yml` is left alone (out of scope).

This module is PHP 8.5-only, so the test matrix and `coverage-php-version` are pinned to `8.5` (and every `php-composer-script` caller passes `php-version: 8.5`).

## Test plan

- [ ] All reusable-backed checks run and pass on PHP 8.5
- [ ] `openemr-compat.yml` still runs unchanged
