### PR TITLE
ci: invoke require-checker via composer script

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,4 +14,4 @@ on:
 
 jobs:
   actionlint:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/actionlint.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/actionlint.yml@0.0.4

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   composer-normalize:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: Normalize composer.json (check)
       run: composer normalize --dry-run

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -25,6 +25,6 @@ jobs:
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
     with:
       name: Run Composer Require Checker
-      run: composer-require-checker check --config-file=.composer-require-checker.json
+      run: composer require-checker
       php-tools: 'composer:v2, composer-require-checker'
       php-version: '8.5'

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   composer-require-checker:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: Run Composer Require Checker
       run: composer require-checker

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   composer-validate:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: Validate composer.json
       run: composer validate --strict

--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   conventional-pr-title:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/conventional-pr-title.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/conventional-pr-title.yml@0.0.4

--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -22,4 +22,4 @@ on:
 
 jobs:
   dclint:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/dclint.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/dclint.yml@0.0.4

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   hadolint:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/hadolint.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/hadolint.yml@0.0.4

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -6,12 +6,14 @@ on:
     - main
     paths:
     - '**.php'
+    - composer.json
     - .github/workflows/php-syntax-check.yml
   pull_request:
     branches:
     - main
     paths:
     - '**.php'
+    - composer.json
     - .github/workflows/php-syntax-check.yml
 
 jobs:

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   php-syntax-check:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: PHP Syntax Check
       run: composer php-lint

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -8,6 +8,8 @@ on:
     - '**.php'
     - '.phpcs.xml*'
     - 'phpcs.xml*'
+    - composer.json
+    - composer.lock
     - .github/workflows/phpcs.yml
   pull_request:
     branches:
@@ -16,6 +18,8 @@ on:
     - '**.php'
     - '.phpcs.xml*'
     - 'phpcs.xml*'
+    - composer.json
+    - composer.lock
     - .github/workflows/phpcs.yml
 
 jobs:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   phpcs:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: Run PHP CodeSniffer
       run: composer phpcs

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   phpstan:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: Run PHPStan
       run: composer phpstan

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   rector:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@0.0.4
     with:
       name: Run Rector (dry-run)
       run: composer rector

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,23 +4,9 @@ on:
   push:
     branches:
     - main
-    paths:
-    - '**.php'
-    - composer.json
-    - composer.lock
-    - phpunit.xml
-    - phpunit.xml.dist
-    - .github/workflows/tests.yml
   pull_request:
     branches:
     - main
-    paths:
-    - '**.php'
-    - composer.json
-    - composer.lock
-    - phpunit.xml
-    - phpunit.xml.dist
-    - .github/workflows/tests.yml
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    uses: openCoreEMR/github-workflows-public/.github/workflows/php-tests.yml@0.0.2
+    uses: openCoreEMR/github-workflows-public/.github/workflows/php-tests.yml@0.0.4
     with:
       php-versions: '["8.5"]'
       coverage-php-version: '8.5'


### PR DESCRIPTION
Calls `composer require-checker` (defined in composer.json) instead of inlining the underlying binary command, so CI uses the same script developers run locally and the command details stay in one place.

Follow-up to the regression caught in openCoreEMR/oce-module-sinch-conversations#132 — the reusable-workflows migration replaced the original `composer require-checker` script call with the inlined `composer-require-checker check ...` invocation. Restoring the script call here.