### PR TITLE
ci(deps): ignore symfony 8 until openemr moves

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
   commit-message:
     prefix: deps
     include: scope
+  ignore:
+  # OpenEMR pins symfony/* at ^7.3; ignore Symfony 8 until upstream moves.
+  - dependency-name: symfony/*
+    versions:
+    - '>=8.0'
 
 # Monitor GitHub Actions
 - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
Add a Dependabot ignore rule for `symfony/* >=8.0` in `.github/dependabot.yml`.

## Why
OpenEMR currently pins `symfony/*` at `^7.3` in its root `composer.json`. When Dependabot bumps this module's `symfony/*` requirement to `^8.x`, the module fails to install into a real OpenEMR site (composer cannot resolve). The recently-closed Symfony 8 PRs in this repo demonstrated the conflict.

This stops the noise of Dependabot reopening Symfony 8 PRs every few weeks. Remove the rule once upstream openemr/openemr widens to `^7.0 || ^8.0` (or moves to `^8.0`).

## Test plan
- [x] `yq .` validates the YAML
- [ ] Confirm Dependabot picks up the new ignore rule on next scan