### PR TITLE
ci: grant `pull-requests: read` to conventional-pr-title caller

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -6,4 +6,6 @@ on:
 
 jobs:
   conventional-pr-title:
+    permissions:
+      pull-requests: read
     uses: openCoreEMR/github-workflows-public/.github/workflows/conventional-pr-title.yml@0.0.4


### PR DESCRIPTION
The reusable workflow at `openCoreEMR/github-workflows-public/.github/workflows/conventional-pr-title.yml` documents in its header that callers must grant `permissions: pull-requests: read` (needed by the title-validation step to read the PR title). This caller was missing it, causing the workflow to fail at startup with a permissions error.

Discovered when the title check failed on a recent PR. Audited all 12 consumers across the org; 10 were missing the block. This is one of the 10.