### PR TITLE
chore(ci): scope dependabot prefixes so release-please skips non-runtime updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,14 +12,13 @@ updates:
   - dependencies
   - composer
   commit-message:
-    prefix: deps
-    include: scope
+    prefix: fix(deps)
+    prefix-development: chore(deps-dev)
   ignore:
   # OpenEMR pins symfony/* at ^7.3; ignore Symfony 8 until upstream moves.
   - dependency-name: symfony/*
     versions:
     - '>=8.0'
-
 # Monitor GitHub Actions
 - package-ecosystem: github-actions
   directory: /
@@ -29,5 +28,4 @@ updates:
   - dependencies
   - github-actions
   commit-message:
-    prefix: deps
-    include: scope
+    prefix: chore(ci)


### PR DESCRIPTION
## Summary

Scope Dependabot's commit-message prefixes so release-please only opens a release PR when something user-facing actually changed.

| Update type | Old prefix | New prefix | Release-please effect |
|---|---|---|---|
| Runtime deps | `deps` | `fix(deps)` | patch bump |
| Dev-only deps | `deps-dev` | `chore(deps-dev)` | no bump (in changelog) |
| GitHub Actions / reusable workflows | `deps` | `chore(ci)` | no bump |

## Why

Today every Dependabot PR lands as `deps:` or `deps-dev:`, both of which release-please's default conventionalcommits config treats as version-bumping. The fleet symptom: release PRs whose only payload is a dev-only bump (rector, phpunit, composer-normalize) or a reusable-workflow update — noise releases that ship nothing user-facing.

## Verified

Tested on openCoreEMR/release-please-test:
- `fix(deps):` → added under **Bug Fixes** in the next release PR (patch bump)
- `chore(deps-dev):` → absent from release PR (no bump)
- `chore(ci):` → absent from release PR (no bump)

## Test plan

- [ ] Merge.
- [ ] Wait for the next Dependabot run.
- [ ] Confirm new PRs use `fix(deps)` / `chore(deps-dev)` / `chore(ci)` prefixes.
- [ ] Confirm release-please does not open a release PR for `chore(...)`-only changes.