### PR TITLE
chore(ci): group reusable workflow Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
   groups:
     github-workflows-public:
       patterns:
-      - "*/github-workflows-public/*"
+      - "openCoreEMR/github-workflows-public/*"
     github-workflows-internal:
       patterns:
-      - "*/github-workflows-internal/*"
+      - "openCoreEMR/github-workflows-internal/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,10 @@ updates:
   - github-actions
   commit-message:
     prefix: chore(ci)
+  groups:
+    github-workflows-public:
+      patterns:
+      - "*/github-workflows-public/*"
+    github-workflows-internal:
+      patterns:
+      - "*/github-workflows-internal/*"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   release-please:
-    uses: opencoreemr/github-workflows-public/.github/workflows/release-please-reusable.yml@1.0.0
+    uses: openCoreEMR/github-workflows-public/.github/workflows/release-please-reusable.yml@1.0.0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Group `openCoreEMR/github-workflows-public/*` reusables into one Dependabot PR per run
- Group `openCoreEMR/github-workflows-internal/*` reusables into one Dependabot PR per run

## Test plan
- [ ] After merge, next Dependabot github-actions run produces grouped PRs instead of per-workflow PRs