### PR TITLE
fix: namespace MockDocument so it no longer collides with OpenEMR's \Document

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -39,7 +39,8 @@ parameters:
         -
             message: '#Property .+ is never read, only written#'
             reportUnmatched: false
-        # Class Document from OpenEMR not typed properly
+        # OpenEMR's global \Document class is unknown during standalone analysis
+        # (it only exists once the module is installed into an OpenEMR tree).
         -
             message: '#class Document#'
             reportUnmatched: false

--- a/tests/Mocks/MockDocument.php
+++ b/tests/Mocks/MockDocument.php
@@ -1,9 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Mock Document class for testing
  *
- * This mocks OpenEMR's Document class used for document management.
+ * Mirrors the subset of OpenEMR's \Document class that this module uses.
+ * It lives in the module's test namespace so that static analyzers running
+ * over an installed OpenEMR tree never see a second global `Document`
+ * declaration competing with the real one. tests/bootstrap.php aliases this
+ * class to the global `\Document` at runtime via class_alias() so code under
+ * test that does `new \Document(...)` resolves to this mock.
+ *
+ * Return types are nullable to match OpenEMR's untyped getters, whose backing
+ * properties default to null (effectively string|null).
  *
  * @package   OpenCoreEMR
  * @link      https://opencoreemr.com
@@ -12,10 +22,9 @@
  * @license   GNU General Public License 3
  */
 
-/**
- * Mock Document class in global namespace to match OpenEMR
- */
-class Document
+namespace OpenCoreEMR\Modules\SinchFax\Tests\Mocks;
+
+class MockDocument
 {
     /**
      * @var array<int, array<string, mixed>>
@@ -64,12 +73,12 @@ class Document
         self::$mockDocuments = [];
     }
 
-    public function get_name(): string
+    public function get_name(): ?string
     {
         return $this->data['name'] ?? '';
     }
 
-    public function get_mimetype(): string
+    public function get_mimetype(): ?string
     {
         return $this->data['mimetype'] ?? 'application/pdf';
     }
@@ -82,10 +91,10 @@ class Document
     /**
      * Get document data (content)
      *
-     * @return string Document content
+     * @return ?string Document content
      * @throws \Exception If configured to throw
      */
-    public function get_data(): string
+    public function get_data(): ?string
     {
         if (isset($this->data['throw_exception']) && $this->data['throw_exception']) {
             throw new \Exception($this->data['exception_message'] ?? 'Document error');

--- a/tests/Unit/Controller/DocumentFaxControllerTest.php
+++ b/tests/Unit/Controller/DocumentFaxControllerTest.php
@@ -12,11 +12,11 @@
 
 namespace OpenCoreEMR\Modules\SinchFax\Tests\Unit\Controller;
 
-use Document;
 use OpenCoreEMR\Modules\SinchFax\Controller\DocumentFaxController;
 use OpenCoreEMR\Modules\SinchFax\Exception\FaxAccessDeniedException;
 use OpenCoreEMR\Modules\SinchFax\GlobalConfig;
 use OpenCoreEMR\Modules\SinchFax\Service\FaxService;
+use OpenCoreEMR\Modules\SinchFax\Tests\Mocks\MockDocument;
 use OpenCoreEMR\Modules\SinchFax\Tests\Mocks\MockGlobalsAccessor;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\SystemLogger;
@@ -37,7 +37,7 @@ class DocumentFaxControllerTest extends TestCase
     protected function setUp(): void
     {
         // Clear mock data
-        Document::clearMockDocuments();
+        MockDocument::clearMockDocuments();
         CsrfUtils::reset();
         SystemLogger::clearLogs();
 
@@ -79,7 +79,7 @@ class DocumentFaxControllerTest extends TestCase
         $_GET = [];
         $_SERVER = [];
         $_SESSION = [];
-        Document::clearMockDocuments();
+        MockDocument::clearMockDocuments();
     }
 
     public function testControllerCanBeConstructed(): void
@@ -139,7 +139,7 @@ class DocumentFaxControllerTest extends TestCase
 
     public function testShowSendFormWithDocumentLoadsDocumentName(): void
     {
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.pdf',
             'foreign_id' => 456,
         ]);
@@ -157,7 +157,7 @@ class DocumentFaxControllerTest extends TestCase
 
     public function testShowSendFormWithDocumentUsesDocumentForeignIdWhenPidEmpty(): void
     {
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.pdf',
             'foreign_id' => 789,
         ]);
@@ -240,7 +240,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'empty-doc.pdf',
             'data' => '', // Empty content
         ]);
@@ -262,7 +262,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'error-doc.pdf',
             'throw_exception' => true,
             'exception_message' => 'Cannot read document',
@@ -287,7 +287,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['patient_id'] = '456';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.pdf',
             'mimetype' => 'application/pdf',
             'data' => '%PDF-1.4 test content',
@@ -314,7 +314,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.tiff',
             'mimetype' => 'image/tiff',
             'data' => 'TIFF image data',
@@ -341,7 +341,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.png',
             'mimetype' => 'image/png',
             'data' => 'PNG image data',
@@ -368,7 +368,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.jpg',
             'mimetype' => 'image/jpeg',
             'data' => 'JPEG image data',
@@ -396,7 +396,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['patient_id'] = ''; // Empty patient ID
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.pdf',
             'mimetype' => 'application/pdf',
             'data' => '%PDF-1.4 test content',
@@ -428,7 +428,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.pdf',
             'mimetype' => 'application/pdf',
             'data' => '%PDF-1.4 test content',
@@ -457,7 +457,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.tif',
             'mimetype' => 'image/tif',
             'data' => 'TIFF image data',
@@ -481,7 +481,7 @@ class DocumentFaxControllerTest extends TestCase
         $_POST['doc_id'] = '123';
         CsrfUtils::setVerifyResult(true);
 
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.jpg',
             'mimetype' => 'image/jpg',
             'data' => 'JPEG image data',
@@ -498,7 +498,7 @@ class DocumentFaxControllerTest extends TestCase
 
     public function testShowSendFormWithProvidedPid(): void
     {
-        Document::setMockDocument(123, [
+        MockDocument::setMockDocument(123, [
             'name' => 'test-document.pdf',
             'foreign_id' => 789,
         ]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,12 +24,19 @@ require_once __DIR__ . '/Mocks/MockQueryUtils.php';
 require_once __DIR__ . '/Mocks/MockCryptoGen.php';
 require_once __DIR__ . '/Mocks/MockCsrfUtils.php';
 require_once __DIR__ . '/Mocks/MockGlobalSetting.php';
-require_once __DIR__ . '/Mocks/MockDocument.php';
 require_once __DIR__ . '/Mocks/MockKernel.php';
 require_once __DIR__ . '/Mocks/MockTwigContainer.php';
 require_once __DIR__ . '/Mocks/MockGlobalsInitializedEvent.php';
 require_once __DIR__ . '/Mocks/MockMenuEvent.php';
 require_once __DIR__ . '/Mocks/MockPatientDocumentEvent.php';
+
+// Alias the namespaced mock to the global \Document that OpenEMR provides at
+// runtime. Done via class_alias (not a global class declaration) so static
+// analyzers running over an installed OpenEMR tree never see a competing
+// \Document definition.
+if (!class_exists('Document', false)) {
+    class_alias(\OpenCoreEMR\Modules\SinchFax\Tests\Mocks\MockDocument::class, 'Document');
+}
 
 // Define OpenEMR global functions used in controllers
 if (!function_exists('xlt')) {


### PR DESCRIPTION
## Summary
- The test mock declared a second **global-namespace** `Document` class with stricter return types (`get_name(): string`, `get_data(): string`) than OpenEMR's real `\Document`, whose getters are untyped and backed by nullable properties (effectively `string|null`). Once the module is installed into an OpenEMR tree, PHPStan and Rector see two `\Document` declarations and conflate them, producing spurious type errors.
- Moved the mock into the test namespace as `OpenCoreEMR\Modules\SinchFax\Tests\Mocks\MockDocument`, mirrored the real class's nullable getter signatures (`?string`), and aliased it to the global `\Document` at test runtime via `class_alias` in `tests/bootstrap.php`.
- `class_alias` is invisible to static analyzers, so no source file declares a competing `\Document`, while `new \Document(...)` in code under test still resolves to the mock.

Fixes #145

## Test plan
- [x] `composer check` — php-lint, phpcs, **PHPStan level 10 (No errors)**, **Rector (clean)**, require-checker all pass
- [x] Full suite: 266 tests pass (`DocumentFaxControllerTest` 22/22)
- [x] Verified the `#class Document#` PHPStan ignore is still required for standalone analysis (removing it → 11 `class.notFound` errors), and clarified its comment