### PR TITLE
chore(ci): use a strategy matrix for composer-script callers

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -13,8 +13,11 @@ on:
 
 jobs:
   composer-normalize:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: Normalize composer.json (check)
       run: composer normalize --dry-run
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -16,9 +16,12 @@ on:
 
 jobs:
   composer-require-checker:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: Run Composer Require Checker
       run: composer require-checker
       php-tools: 'composer:v2, composer-require-checker'
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -13,9 +13,12 @@ on:
 
 jobs:
   composer-validate:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: Validate composer.json
       run: composer validate --strict
       install-deps: false
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/php-syntax-check.yml
+++ b/.github/workflows/php-syntax-check.yml
@@ -14,9 +14,12 @@ on:
 
 jobs:
   php-syntax-check:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: PHP Syntax Check
       run: composer php-lint
       install-deps: false
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -17,8 +17,11 @@ on:
 
 jobs:
   phpcs:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: Run PHP CodeSniffer
       run: composer phpcs
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,8 +18,11 @@ on:
 
 jobs:
   phpstan:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: Run PHPStan
       run: composer phpstan
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -16,8 +16,11 @@ on:
 
 jobs:
   rector:
+    strategy:
+      matrix:
+        php-version: ['8.5']
     uses: openCoreEMR/github-workflows-public/.github/workflows/php-composer-script.yml@1.0.0
     with:
       name: Run Rector (dry-run)
       run: composer rector
-      php-version: '8.5'
+      php-version: ${{ matrix.php-version }}


### PR DESCRIPTION
## Summary
- Convert the scalar `php-version: '8.5'` on each composer-script caller workflow to a single-entry `strategy.matrix` that feeds the reusable.
- Affects 7 caller workflows: phpstan, phpcs, rector, composer-require-checker, composer-normalize, composer-validate, php-syntax-check.

## Why
Per the OCE GitHub Actions standard, version-parameterized jobs must always use a `strategy.matrix`, even with a single version. Adding another PHP version later becomes a one-line change instead of restructuring the job.

Matches the pattern in openCoreEMR/oce-module-sinch-conversations#181.

## Test plan
- [x] actionlint clean on all 7 modified workflows
- [ ] CI green on this PR